### PR TITLE
Feature/dockerization

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,25 @@ curl -X GET "https://api.textbee.dev/api/v1/gateway/devices/YOUR_DEVICE_ID/get-r
    ```
 4. Ensure your domain points to your VPS and Caddy is configured properly.
 
+### Dockerized env
+#### Requirements:   
+- Docker installed
+- docker-compose installed
+1. After setting up Firebase, update your `.env` in `web` && `api` folder.
+   ```bash
+   cd web && cp .env.example .env \
+   && cd ../api && cp .env.example .env
+   ```
+2. Navigate to root folder and execute docker-compose.yml file.    
+   This will spin up `web` container, `api` container alongside with `MongoDB` and `MongoExpress`. `TextBee` database will be automatically created.
+   ```bash
+   docker-compose up -d
+   ```
+   To stop the containers simply type
+   ```bash
+   docker-compose down
+   ```   
+
 ## Contributing
 
 Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ curl -X GET "https://api.textbee.dev/api/v1/gateway/devices/YOUR_DEVICE_ID/get-r
 ### Dockerized env
 #### Requirements:   
 - Docker installed
-- docker-compose installed
 1. After setting up Firebase, update your `.env` in `web` && `api` folder.
    ```bash
    cd web && cp .env.example .env \
@@ -170,11 +169,11 @@ curl -X GET "https://api.textbee.dev/api/v1/gateway/devices/YOUR_DEVICE_ID/get-r
 2. Navigate to root folder and execute docker-compose.yml file.    
    This will spin up `web` container, `api` container alongside with `MongoDB` and `MongoExpress`. `TextBee` database will be automatically created.
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
    To stop the containers simply type
    ```bash
-   docker-compose down
+   docker compose down
    ```   
 
 ## Contributing

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,4 +1,3 @@
 /dist
 /node_modules
 /coverage
-.env

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,10 +1,11 @@
-PORT=
-MONGO_URI=mongodb://textbee-db:27017/textbee
+PORT=3005
+MONGO_URI=mongodb://textbeeUser:textbeePassword@mongo:27017/TextBee
 JWT_SECRET=secret
 JWT_EXPIRATION=60d
 
-FRONTEND_URL=
+FRONTEND_URL=http://localhost:3000
 
+#Update from Firebase json file
 FIREBASE_PROJECT_ID=
 FIREBASE_PRIVATE_KEY_ID=
 FIREBASE_PRIVATE_KEY=

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS base
+FROM node:18-alpine AS base
 RUN npm i -g pnpm
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
@@ -13,11 +13,13 @@ FROM base AS build
 ENV NODE_ENV=production
 RUN pnpm build
 
-FROM node:lts-alpine AS prod
+FROM node:18-alpine AS prod
 ENV NODE_ENV=production
+EXPOSE 3005
 WORKDIR /app
 RUN npm i -g pnpm
-COPY --from=build /app/dist ./dist 
-COPY --from=build /app/package.json /app/pnpm-lock.yaml ./ 
+COPY --from=build /app/.env ./.env
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json /app/pnpm-lock.yaml ./
 RUN pnpm i --prod
 ENTRYPOINT ["pnpm", "start"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,36 +1,56 @@
 services:
-  textbee-web:
-    image: ghcr.io/vernu/textbee/web:latest
-    container_name: textbee-web
-    build: 
+  web:
+    container_name: web
+    build:
       context: ./web
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
-    env_file: 
-      - path: ./web/.env
-        required: true
-    command: pnpm start
-  textbee-api:
-    image: ghcr.io/vernu/textbee/api:latest
-    container_name: textbee-api
-    build: 
+    depends_on:
+      - mongo
+    environment:
+      NODE_ENV: production
+
+  api:
+    container_name: api
+    build:
       context: ./api
       dockerfile: Dockerfile
+      target: prod
     ports:
       - "3005:3005"
-    env_file: 
-      - path: ./api/.env
-        required: true
     depends_on:
-      - textbee-db
-  textbee-db:
+      - mongo
+    environment:
+      NODE_ENV: production
+
+  mongo:
+    container_name: mongo
     image: mongo
-    container_name: textbee-db
-    volumes:
-      - textbee-db-data:/data/db
+    restart: always
     ports:
       - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: adminUser
+      MONGO_INITDB_ROOT_PASSWORD: adminPassword
+      MONGO_INITDB_DATABASE: TextBee
+    volumes:
+      - textbee-db-data:/data/db
+      # THe following scripts creates TextBee DB automatically, also the user which web and api are connecting with.
+      - ./mongo-init:/docker-entrypoint-initdb.d:ro
+  mongo-express:
+    container_name: mongo-ee
+    image: mongo-express
+    restart: always
+    ports:
+      - "8081:8081"
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: adminUser
+      ME_CONFIG_MONGODB_ADMINPASSWORD: adminPassword
+      ME_CONFIG_MONGODB_URL: mongodb://adminUser:adminPassword@mongo:27017/
+      ME_CONFIG_BASICAUTH: "false"
+    depends_on:
+      - mongo
 
 volumes:
   textbee-db-data:

--- a/mongo-init/init.js
+++ b/mongo-init/init.js
@@ -1,0 +1,11 @@
+db = db.getSiblingDB("TextBee");
+
+db.createUser({
+  user: "textbeeUser",
+  pwd: "textbeePassword",
+  roles: [{ role: "readWrite", db: "TextBee" }]
+});
+
+db.init.insertOne({ createdBy: "seed" });
+
+print("✅ TextBee DB initialized and user created.");

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,11 +1,11 @@
-NEXT_PUBLIC_API_BASE_URL=https://api.textbee.dev/api/v1
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3005/api/v1
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 NEXT_PUBLIC_TAWKTO_EMBED_URL=
 
-NEXTAUTH_URL=http://localhost:3000
 AUTH_SECRET= # https://generate-secret.vercel.app/32
 
-DATABASE_URL=
+DATABASE_URL=mongodb://textbeeUser:textbeePassword@mongo:27017/TextBee
 
 MAIL_HOST=
 MAIL_PORT=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,8 +1,9 @@
-FROM node:lts-alpine AS base
+FROM node:18-alpine AS base
 
 # Stage 1: Install web dependencies
 FROM base AS web-deps
 WORKDIR /app
+COPY .env ./.env
 COPY package.json pnpm-lock.yaml ./
 RUN corepack enable pnpm && pnpm install --frozen-lockfile
 
@@ -13,6 +14,7 @@ EXPOSE 3000
 WORKDIR /app
 COPY . .
 COPY --from=web-deps /app/node_modules ./node_modules
+COPY --from=web-deps /app/.env .env
 RUN corepack enable pnpm && pnpm run vercel-build
 
 CMD ["pnpm", "start"]


### PR DESCRIPTION
the change here is for running the app locally, using docker-compose.. 

changes are made to the following files:

`docker-compose.yml`
building local dockerfile instead of pulling public textbee
creating automatically DB and user/pass when running mongodb container and also starting mongo express
removing .env files since they are included in the dockerfile. the apps are using automatically .env if the files are present in the image.

`api/Dockerfile && web/Dockerfile`
added fixed version of base image (node:18) coz it was pulling latest which is node 22 and app was not working.

`mongo-init`
this folder consist a js script which is executed when mongo container is starting. it creates the DB and also User/Pass for the web and api to use for connection.

`api/.dockerignore`
i had to remove .env from .docklerignore coz docker build was failing, coudnt find .env to copy to.

also updated Readme file with steps on running the apps locally.