### PR TITLE
prefill polar customer portal url with user email

### DIFF
--- a/web/app/(app)/dashboard/(components)/account-settings.tsx
+++ b/web/app/(app)/dashboard/(components)/account-settings.tsx
@@ -43,6 +43,7 @@ import { Textarea } from '@/components/ui/textarea'
 import axios from 'axios'
 import { useSession } from 'next-auth/react'
 import { Routes } from '@/config/routes'
+import { polarCustomerPortalRequestUrl } from '@/config/external-links'
 import {
   Tooltip,
   TooltipContent,
@@ -448,7 +449,7 @@ export default function AccountSettings() {
             </Link>
           ) : (
             <Link
-              href='https://polar.sh/textbee/portal/'
+              href={polarCustomerPortalRequestUrl(currentUser?.email)}
               className='text-xs font-medium bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 px-3 py-1.5 rounded-md transition-colors'
             >
               Manage Subscription →

--- a/web/app/(app)/dashboard/(components)/subscription-info.tsx
+++ b/web/app/(app)/dashboard/(components)/subscription-info.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '@/components/ui/spinner'
 import { useQuery } from '@tanstack/react-query'
 import httpBrowserClient from '@/lib/httpBrowserClient'
 import { ApiEndpoints } from '@/config/api'
+import { polarCustomerPortalRequestUrl } from '@/config/external-links'
 import Link from 'next/link'
 import {
   Tooltip,
@@ -25,6 +26,14 @@ export default function SubscriptionInfo() {
       httpBrowserClient
         .get(ApiEndpoints.billing.currentSubscription())
         .then((res) => res.data),
+  })
+
+  const { data: currentUser } = useQuery({
+    queryKey: ['currentUser'],
+    queryFn: () =>
+      httpBrowserClient
+        .get(ApiEndpoints.auth.whoAmI())
+        .then((res) => res.data?.data),
   })
 
   // Format price with currency symbol
@@ -254,7 +263,7 @@ export default function SubscriptionInfo() {
           </Link>
         ) : (
           <Link
-            href='https://polar.sh/textbee/portal/'
+            href={polarCustomerPortalRequestUrl(currentUser?.email)}
             className='text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 px-4 py-2 rounded-md transition-colors'
           >
             Manage Subscription →

--- a/web/config/external-links.ts
+++ b/web/config/external-links.ts
@@ -1,3 +1,14 @@
+const POLAR_CUSTOMER_PORTAL_REQUEST_BASE =
+  'https://polar.sh/textbee/portal/request'
+
+export function polarCustomerPortalRequestUrl(
+  email?: string | null
+): string {
+  const trimmed = email?.trim()
+  if (!trimmed) return POLAR_CUSTOMER_PORTAL_REQUEST_BASE
+  return `${POLAR_CUSTOMER_PORTAL_REQUEST_BASE}?email=${encodeURIComponent(trimmed)}`
+}
+
 export const ExternalLinks = {
   patreon: 'https://patreon.com/vernu',
   github: 'https://github.com/vernu/textbee',


### PR DESCRIPTION
Add polarCustomerPortalRequestUrl() pointing to /portal/request with a URL-encoded email query when available. Wire Manage Subscription links in account settings and subscription info; subscription info loads currentUser via whoAmI (shared React Query cache with account settings).

Made-with: Cursor