### PR TITLE
bind server to 0.0.0.0 for cloud platform compatibility

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,4 +1,9 @@
 PORT=3001
+
+# Self-hosted mode: set to true to disable all plan/billing limits.
+# When true, all users have unlimited access regardless of subscription.
+# Defaults to false (billing enforced) if not set.
+SELF_HOSTED=false
 MONGO_URI=mongodb://adminUser:adminPassword@textbee-db:27017/textbee?authSource=admin
 
 # to setup initial password

--- a/api/src/billing/billing.service.ts
+++ b/api/src/billing/billing.service.ts
@@ -512,6 +512,12 @@ export class BillingService {
     action: 'send_sms' | 'receive_sms' | 'bulk_send_sms',
     value: number,
   ) {
+    // Self-hosted mode: bypass all plan/billing limits entirely.
+    // Set SELF_HOSTED=true in your environment to enable this.
+    if (process.env.SELF_HOSTED === 'true') {
+      return true
+    }
+
     try {
       const user = await this.userModel.findById(userId)
       if (user.isBanned) {

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -77,6 +77,6 @@ async function bootstrap() {
   )
   app.useBodyParser('json', { limit: '2mb' });
   app.enableCors()
-  await app.listen(PORT)
+  await app.listen(PORT, '0.0.0.0')
 }
 bootstrap()

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -77,6 +77,13 @@ async function bootstrap() {
   )
   app.useBodyParser('json', { limit: '2mb' });
   app.enableCors()
+
+  // Lightweight health check endpoint for uptime monitors
+  const httpAdapter = app.getHttpAdapter()
+  httpAdapter.get('/health', (req: any, res: any) => {
+    res.status(200).json({ status: 'ok' })
+  })
+
   await app.listen(PORT, '0.0.0.0')
 }
 bootstrap()

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,4 +1,9 @@
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# Self-hosted mode: set to true to hide all billing/upgrade UI in the dashboard.
+# Must match the SELF_HOSTED value set in the API environment.
+# Defaults to false (billing UI visible) if not set.
+NEXT_PUBLIC_SELF_HOSTED=false
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3001/api/v1
 NEXT_PUBLIC_LATEST_APP_VERSION_CODE=17
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=

--- a/web/app/(app)/dashboard/(components)/past-due-billing-alert.tsx
+++ b/web/app/(app)/dashboard/(components)/past-due-billing-alert.tsx
@@ -9,6 +9,9 @@ import { useQuery } from '@tanstack/react-query'
 import { CreditCard, AlertTriangle } from 'lucide-react'
 import Link from 'next/link'
 
+// Self-hosted mode: hide billing alerts when NEXT_PUBLIC_SELF_HOSTED=true
+const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOSTED === 'true'
+
 export default function PastDueBillingAlert() {
   const { data: currentSubscription, isLoading: subLoading } = useQuery({
     queryKey: ['currentSubscription'],
@@ -25,6 +28,9 @@ export default function PastDueBillingAlert() {
         .get(ApiEndpoints.auth.whoAmI())
         .then((res) => res.data?.data),
   })
+
+  // Self-hosted mode: no billing alerts ever
+  if (isSelfHosted) return null
 
   if (subLoading || userLoading || !currentSubscription || !currentUser) {
     return null

--- a/web/app/(app)/dashboard/(components)/subscription-info.tsx
+++ b/web/app/(app)/dashboard/(components)/subscription-info.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Calendar, Check, Info } from 'lucide-react'
+import { Calendar, Check, Info, Server } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Spinner } from '@/components/ui/spinner'
 import { useQuery } from '@tanstack/react-query'
@@ -14,6 +14,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+
+// Self-hosted mode: show unlimited plan card when NEXT_PUBLIC_SELF_HOSTED=true
+const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOSTED === 'true'
 
 export default function SubscriptionInfo() {
   const {
@@ -71,6 +74,51 @@ export default function SubscriptionInfo() {
       </p>
     )
 
+  // Self-hosted mode: render a simplified unlimited plan card
+  if (isSelfHosted) {
+    return (
+      <div className='bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-900 border rounded-lg shadow p-5'>
+        <div className='flex items-center justify-between mb-5'>
+          <div>
+            <h3 className='text-xl font-bold text-gray-900 dark:text-white'>
+              Self-Hosted
+            </h3>
+            <p className='text-sm text-gray-500 dark:text-gray-400'>
+              Self-hosted instance — no limits applied
+            </p>
+          </div>
+          <div className='flex items-center px-2 py-0.5 rounded-full bg-green-50 dark:bg-green-900/30'>
+            <Check className='h-3 w-3 mr-1 text-green-600 dark:text-green-400' />
+            <span className='text-xs font-medium text-green-600 dark:text-green-400'>
+              Active
+            </span>
+          </div>
+        </div>
+
+        <div className='bg-white dark:bg-gray-800 p-4 rounded-md shadow-sm mb-5'>
+          <p className='text-xs text-gray-500 dark:text-gray-400 mb-3 font-medium'>
+            Usage Limits
+          </p>
+          <div className='grid grid-cols-3 gap-3'>
+            {['Daily', 'Monthly', 'Bulk'].map((label) => (
+              <div key={label} className='bg-gray-50 dark:bg-gray-700/50 p-2 rounded-md'>
+                <p className='text-xs text-gray-500 dark:text-gray-400'>{label}</p>
+                <p className='text-sm font-medium text-gray-900 dark:text-white'>
+                  Unlimited
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className='flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400'>
+          <Server className='h-3.5 w-3.5 shrink-0' />
+          <span>Billing is disabled in self-hosted mode</span>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className='bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-900 border rounded-lg shadow p-5'>
       <div className='flex items-center justify-between mb-5'>
@@ -90,6 +138,7 @@ export default function SubscriptionInfo() {
                 )}
                 {currentSubscription?.recurringInterval && (
                   <span className='ml-1'>
+                    {' '}
                     /{' '}
                     {getBillingInterval(currentSubscription?.recurringInterval)}
                   </span>

--- a/web/app/(app)/dashboard/(components)/upgrade-to-pro-alert.tsx
+++ b/web/app/(app)/dashboard/(components)/upgrade-to-pro-alert.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { ApiEndpoints } from '@/config/api'
@@ -19,6 +21,9 @@ const discountPercentage = (envDiscountPercentage !== undefined && envDiscountPe
   ? envDiscountPercentage
   : DISCOUNT_PERCENTAGE_FALLBACK
 const isDiscountEnabled = discountCode !== null && discountCode !== '' && discountPercentage !== null && discountPercentage !== ''
+
+// Self-hosted mode: hide all upgrade prompts when NEXT_PUBLIC_SELF_HOSTED=true
+const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOSTED === 'true'
 
 export default function UpgradeToProAlert() {
   const {
@@ -109,6 +114,9 @@ export default function UpgradeToProAlert() {
       }
     }
   }, [monthlyUsagePercentage, monthlyLimit, processedSmsLastMonth])
+
+  // Self-hosted mode: never show upgrade prompts
+  if (isSelfHosted) return null
 
   if (isLoadingSubscription || !currentSubscription || subscriptionError) {
     return null

--- a/web/components/shared/rate-limit-error.tsx
+++ b/web/components/shared/rate-limit-error.tsx
@@ -6,6 +6,9 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { AlertCircle } from 'lucide-react'
 import type { RateLimitErrorData } from '@/lib/utils/errorHandler'
 
+// Self-hosted mode: never show upgrade prompts when NEXT_PUBLIC_SELF_HOSTED=true
+const isSelfHosted = process.env.NEXT_PUBLIC_SELF_HOSTED === 'true'
+
 interface RateLimitErrorProps {
   errorData?: RateLimitErrorData
   variant?: 'alert' | 'inline'
@@ -26,14 +29,16 @@ export function RateLimitError({
     return (
       <div className={`flex flex-col gap-2 ${className || ''}`}>
         <p className="text-sm text-destructive">{message}</p>
-        <div className="flex gap-2 flex-wrap">
-          <Button asChild variant="default" size="sm">
-            <Link href="/checkout/pro">Upgrade Plan</Link>
-          </Button>
-          <p className="text-xs text-muted-foreground flex items-center">
-            or wait for your limit to reset
-          </p>
-        </div>
+        {!isSelfHosted && (
+          <div className="flex gap-2 flex-wrap">
+            <Button asChild variant="default" size="sm">
+              <Link href="/checkout/pro">Upgrade Plan</Link>
+            </Button>
+            <p className="text-xs text-muted-foreground flex items-center">
+              or wait for your limit to reset
+            </p>
+          </div>
+        )}
       </div>
     )
   }
@@ -44,14 +49,16 @@ export function RateLimitError({
       <AlertTitle>Limit Reached</AlertTitle>
       <AlertDescription className="flex flex-col gap-3 mt-2">
         <p>{message}</p>
-        <div className="flex gap-2 flex-wrap items-center">
-          <Button asChild variant="outline" size="sm">
-            <Link href="/checkout/pro">Upgrade Plan</Link>
-          </Button>
-          <span className="text-xs text-muted-foreground">
-            or wait for your limit to reset
-          </span>
-        </div>
+        {!isSelfHosted && (
+          <div className="flex gap-2 flex-wrap items-center">
+            <Button asChild variant="outline" size="sm">
+              <Link href="/checkout/pro">Upgrade Plan</Link>
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              or wait for your limit to reset
+            </span>
+          </div>
+        )}
       </AlertDescription>
     </Alert>
   )
@@ -65,5 +72,6 @@ export function formatRateLimitMessageForToast(
   errorData?: RateLimitErrorData
 ): string {
   const baseMessage = errorData?.message || 'You have reached your usage limit.'
+  if (isSelfHosted) return baseMessage
   return `${baseMessage} Please upgrade your plan or wait for your limit to reset.`
 }


### PR DESCRIPTION
Platforms like Render, Railway, and Fly.io require the server to listen on 0.0.0.0 (all interfaces) rather than the default localhost/127.0.0.1. Without this, the platform's port scanner can't detect the open port and the deployment fails.
Changed app.listen(PORT) → app.listen(PORT, '0.0.0.0') in api/src/main.ts.