### PR TITLE
fix failing docker build

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -45,19 +45,19 @@ jobs:
                   ref: ${{ github.event.inputs.git_ref || github.ref }}
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v2
+              uses: docker/setup-qemu-action@v3
               with:
                   platforms: "arm64,amd64"
 
             # Workaround: https://github.com/docker/build-push-action/issues/461
             - name: Setup Docker buildx
-              uses: docker/setup-buildx-action@v2
+              uses: docker/setup-buildx-action@v3
 
             # Login against a Docker registry except on PR
             # https://github.com/docker/login-action
             - name: Log into registry ${{ env.REGISTRY }}
               if: github.event_name != 'pull_request'
-              uses: docker/login-action@v2
+              uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
             - name: Extract Docker metadata for API
               id: meta-api
               if: ${{ github.event.inputs.image_name == 'api' || github.event.inputs.image_name == 'both' || github.event_name != 'workflow_dispatch' }}
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@v6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   images: ${{ env.REGISTRY }}/${{ github.repository }}/api
@@ -84,7 +84,7 @@ jobs:
             - name: Build and push Docker image for API
               id: build-and-push-api
               if: ${{ github.event.inputs.image_name == 'api' || github.event.inputs.image_name == 'both' || github.event_name != 'workflow_dispatch' }}
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v6
               with:
                   context: api
                   build-args: VERSION=${{ github.event.inputs.git_ref || github.ref_name }}
@@ -98,7 +98,7 @@ jobs:
             - name: Extract Docker metadata for Web
               id: meta-web
               if: ${{ github.event.inputs.image_name == 'web' || github.event.inputs.image_name == 'both' || github.event_name != 'workflow_dispatch' }}
-              uses: docker/metadata-action@v5
+              uses: docker/metadata-action@v6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   images: ${{ env.REGISTRY }}/${{ github.repository }}/web
@@ -114,7 +114,7 @@ jobs:
             - name: Build and push Docker image for Web
               id: build-and-push-web
               if: ${{ github.event.inputs.image_name == 'web' || github.event.inputs.image_name == 'both' || github.event_name != 'workflow_dispatch' }}
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v6
               with:
                   context: web
                   build-args: VERSION=${{ github.event.inputs.git_ref || github.ref_name }}

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22-alpine AS deps
 WORKDIR /app
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm@9
 
 # Copy package.json and pnpm-lock.yaml
 COPY package.json pnpm-lock.yaml ./
@@ -16,7 +16,7 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm@9
 
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
@@ -30,7 +30,7 @@ FROM node:22-alpine AS runner
 WORKDIR /app
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm@9
 
 # Set NODE_ENV to production
 ENV NODE_ENV production

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install pnpm and required OpenSSL dependencies
 RUN apk add --no-cache openssl openssl-dev
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm@9
 
 # Copy package.json and pnpm-lock.yaml
 COPY package.json pnpm-lock.yaml ./
@@ -18,7 +18,7 @@ WORKDIR /app
 
 # Install pnpm and required OpenSSL dependencies
 RUN apk add --no-cache openssl openssl-dev
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm@9
 
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
@@ -39,7 +39,7 @@ WORKDIR /app
 
 # Install pnpm and required OpenSSL dependencies
 RUN apk add --no-cache openssl openssl-dev
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm@9
 
 # Set environment variables
 ENV NODE_ENV production


### PR DESCRIPTION
pnpm v10 is now the npm "latest" tag but generates a different lockfile format than v9.0 used in this repo, causing --frozen-lockfile to fail. Replace corepack pnpm@latest with npm install -g pnpm@9 in api and web Dockerfiles. Also bump docker/* actions to v3/v6 to resolve Node.js 20 deprecation warnings ahead of the June 2026 forced migration.