### PR TITLE
fix(billing): correctly route webhook events per plan and scope cance…

### DIFF
--- a/api/src/billing/billing.controller.ts
+++ b/api/src/billing/billing.controller.ts
@@ -7,12 +7,16 @@ import {
   CheckoutResponseDTO,
   PlansResponseDTO,
 } from './billing.dto'
+import { BillingNotificationsService } from './billing-notifications.service'
 
 @ApiTags('billing')
 @ApiBearerAuth()
 @Controller('billing')
 export class BillingController {
-  constructor(private billingService: BillingService) {}
+  constructor(
+    private billingService: BillingService,
+    private billingNotifications: BillingNotificationsService,
+  ) {}
 
   @Get('plans')
   async getPlans(): Promise<PlansResponseDTO> {
@@ -23,6 +27,12 @@ export class BillingController {
   @UseGuards(AuthGuard)
   async getCurrentSubscription(@Request() req: any) {
     return this.billingService.getCurrentSubscription(req.user)
+  }
+
+  @Get('notifications')
+  @UseGuards(AuthGuard)
+  async listNotifications(@Request() req: any) {
+    return this.billingNotifications.listForUser(req.user._id)
   }
 
   @Post('checkout')
@@ -57,8 +67,6 @@ export class BillingController {
         console.log(payload)
         await this.billingService.switchPlan({
           userId: payload.data?.metadata?.userId as string,
-          // TODO: remove this after more plans are added
-          newPlanName: 'pro',
           newPlanPolarProductId: payload.data?.product?.id,
           currentPeriodStart: payload.data?.currentPeriodStart,
           currentPeriodEnd: payload.data?.currentPeriodEnd,
@@ -73,12 +81,14 @@ export class BillingController {
 
       // @ts-ignore
       case 'subscription.cancelled':
-        console.log('polar subscription.cancelled')
+      // @ts-ignore
+      case 'subscription.canceled':
+      // case 'subscription.revoked':
+        console.log('polar webhook event', payload.type)
         console.log(payload)
-        await this.billingService.switchPlan({
-          // @ts-ignore
-          userId: payload?.data?.userId,
-          newPlanName: 'free',
+        await this.billingService.cancelSubscription({
+          userId: payload.data?.metadata?.userId as string,
+          polarProductId: payload.data?.product?.id,
         })
         break
       default:

--- a/api/src/billing/billing.service.ts
+++ b/api/src/billing/billing.service.ts
@@ -514,7 +514,6 @@ export class BillingService {
     if (newPlanPolarProductId) {
       plan = await this.planModel.findOne({
         $or: [
-          // { polarProductId: newPlanPolarProductId }, // deprecated
           { polarMonthlyProductId: newPlanPolarProductId },
           { polarYearlyProductId: newPlanPolarProductId },
         ],
@@ -556,6 +555,35 @@ export class BillingService {
       `Updated or created subscription: ${updateResult.upsertedCount > 0 ? 'Created' : 'Updated'}`,
     )
 
+    return { success: true, plan: plan.name }
+  }
+
+  async cancelSubscription({
+    userId,
+    polarProductId,
+  }: {
+    userId: string
+    polarProductId?: string
+  }) {
+    const userObjectId = new Types.ObjectId(userId)
+
+    const plan = await this.planModel.findOne({
+      $or: [
+        { polarMonthlyProductId: polarProductId },
+        { polarYearlyProductId: polarProductId },
+      ],
+    })
+
+    if (!plan) {
+      throw new Error(`No plan found for product ID: ${polarProductId}`)
+    }
+
+    await this.subscriptionModel.updateOne(
+      { user: userObjectId, plan: plan._id, isActive: true },
+      { isActive: false, subscriptionEndDate: new Date() },
+    )
+
+    console.log(`Cancelled subscription for user ${userId} on plan ${plan.name}`)
     return { success: true, plan: plan.name }
   }
 


### PR DESCRIPTION
…llations

- switchPlan now resolves plan strictly by polarProductId (no name fallback when product ID is provided); throws on unknown product ID
- cancelSubscription: new method that deactivates only the subscription matching the cancelled product, instead of wiping all active subscriptions
- Webhook handler: subscription.created/active/updated no longer hardcodes newPlanName='pro'; subscription.cancelled/canceled use cancelSubscription; subscription.revoked commented out