### PR TITLE
fix(web): include start/end in webhook notifications query key

### DIFF
--- a/web/lib/api/hooks.test.tsx
+++ b/web/lib/api/hooks.test.tsx
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
 import { TestProviders } from '@/test/render'
-import { mockDevices, mockSubscription, mockUser } from '@/test/fixtures'
-import { useCurrentUser, useDevices, useSubscription } from './hooks'
+import { API_BASE_URL, mockDevices, mockSubscription, mockUser } from '@/test/fixtures'
+import { server } from '@/test/msw/server'
+import { ApiEndpoints } from '@/config/api'
+import {
+  useCurrentUser,
+  useDevices,
+  useSubscription,
+  useWebhookNotifications,
+} from './hooks'
 
 // Verifies the typed hooks talk to the mocked API and unwrap the various
 // response envelopes correctly. No real backend is contacted (MSW).
@@ -26,5 +34,43 @@ describe('data hooks', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data).toHaveLength(mockDevices.length)
     expect(result.current.data?.[0]._id).toBe(mockDevices[0]._id)
+  })
+
+  // Regression for #256: start/end were query params but not query-key
+  // members, so changing the date filter reused a cached response.
+  it('useWebhookNotifications refetches when the date range changes', async () => {
+    const startsSeen: string[] = []
+    server.use(
+      http.get(
+        `${API_BASE_URL}${ApiEndpoints.gateway.getWebhookNotifications().split('?')[0]}`,
+        ({ request }) => {
+          const start = new URL(request.url).searchParams.get('start') ?? ''
+          startsSeen.push(start)
+          return HttpResponse.json({
+            data: { data: [], meta: { totalPages: 1, total: 0 } },
+          })
+        }
+      )
+    )
+
+    const { result, rerender } = renderHook(
+      ({ start }) => useWebhookNotifications({ start, page: 1, limit: 10 }),
+      {
+        wrapper,
+        initialProps: { start: '2026-08-01T00:00:00.000Z' },
+      }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(startsSeen).toEqual(['2026-08-01T00:00:00.000Z'])
+
+    rerender({ start: '2026-07-01T00:00:00.000Z' })
+
+    await waitFor(() =>
+      expect(startsSeen).toEqual([
+        '2026-08-01T00:00:00.000Z',
+        '2026-07-01T00:00:00.000Z',
+      ])
+    )
   })
 })

--- a/web/lib/api/hooks.ts
+++ b/web/lib/api/hooks.ts
@@ -343,15 +343,16 @@ export function useWebhookNotifications(filters: WebhookNotificationFilters) {
     limit = 10,
   } = filters
   return useQuery({
-    queryKey: [
-      'webhook-notification',
+    queryKey: queryKeys.webhookNotifications({
       eventType,
-      page,
-      limit,
+      status,
       deviceId,
       webhookSubscriptionId,
-      status,
-    ],
+      start,
+      end,
+      page,
+      limit,
+    }),
     queryFn: () =>
       httpBrowserClient
         .get(

--- a/web/lib/api/query-keys.test.ts
+++ b/web/lib/api/query-keys.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { queryKeys } from './query-keys'
+
+describe('queryKeys.webhookNotifications', () => {
+  it('includes start and end so date filter changes produce a new cache entry', () => {
+    const base = {
+      eventType: '',
+      status: '',
+      deviceId: '',
+      webhookSubscriptionId: '',
+      page: 1,
+      limit: 10,
+    }
+
+    const withoutDates = queryKeys.webhookNotifications(base)
+    const withStart = queryKeys.webhookNotifications({
+      ...base,
+      start: '2026-08-01T00:00:00.000Z',
+    })
+    const withRange = queryKeys.webhookNotifications({
+      ...base,
+      start: '2026-08-01T00:00:00.000Z',
+      end: '2026-08-02T00:00:00.000Z',
+    })
+    const differentStart = queryKeys.webhookNotifications({
+      ...base,
+      start: '2026-07-01T00:00:00.000Z',
+      end: '2026-08-02T00:00:00.000Z',
+    })
+
+    expect(withoutDates).not.toEqual(withStart)
+    expect(withStart).not.toEqual(withRange)
+    expect(withRange).not.toEqual(differentStart)
+
+    // Guard against dropping date params from the key shape again.
+    expect(withRange).toEqual([
+      'webhook-notification',
+      '',
+      1,
+      10,
+      '',
+      '',
+      '',
+      '2026-08-01T00:00:00.000Z',
+      '2026-08-02T00:00:00.000Z',
+    ])
+  })
+})

--- a/web/lib/api/query-keys.ts
+++ b/web/lib/api/query-keys.ts
@@ -22,4 +22,27 @@ export const queryKeys = {
     filters
       ? (['messages', deviceId, filters] as const)
       : (['messages', deviceId] as const),
+  // start/end must be part of the key: they are sent on the request URL, and
+  // react-query only refetches when the key changes (see issue #256).
+  webhookNotifications: (filters: {
+    eventType?: string
+    status?: string
+    deviceId?: string
+    webhookSubscriptionId?: string
+    start?: string
+    end?: string
+    page?: number
+    limit?: number
+  }) =>
+    [
+      'webhook-notification',
+      filters.eventType ?? '',
+      filters.page ?? 1,
+      filters.limit ?? 10,
+      filters.deviceId ?? '',
+      filters.webhookSubscriptionId ?? '',
+      filters.status ?? '',
+      filters.start ?? '',
+      filters.end ?? '',
+    ] as const,
 }


### PR DESCRIPTION
## Summary
`useWebhookNotifications` sent `start` and `end` as request query params but omitted them from the react-query `queryKey`. Changing the webhook history date filter therefore reused a cached response instead of refetching.

This moves the key into `queryKeys.webhookNotifications` (including `start`/`end`) and adds regression coverage.

Fixes #256

## Test plan
- [x] `npx vitest run lib/api/query-keys.test.ts lib/api/hooks.test.tsx lib/api/cache-invalidation.test.tsx` (7/7)
- [x] `npx vitest run` in `web/` (195/195)
- [x] `npx tsc --noEmit` in `web/`
- [x] `npx eslint` on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed webhook notification results being incorrectly reused when changing the start or end date filters.
  - Notification searches now refresh with the latest filter and pagination settings, ensuring results match the selected criteria.

- **Tests**
  - Added coverage to verify that different date ranges produce distinct notification results and requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->