### PR TITLE
Make Swagger UI actually send the x-api-key header

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -12,7 +12,13 @@ import {
   Request,
   UseGuards,
 } from '@nestjs/common'
-import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger'
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger'
 import {
   LoginInputDTO,
   RegisterInputDTO,
@@ -58,6 +64,7 @@ export class AuthController {
 
   @ApiOperation({ summary: 'Get current logged in user' })
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
   @Get('/who-am-i')
   async whoAmI(@Request() req) {
@@ -67,6 +74,7 @@ export class AuthController {
   @ApiOperation({ summary: 'Update Profile' })
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
   @Patch('/update-profile')
   async updateProfile(
@@ -79,6 +87,7 @@ export class AuthController {
   @ApiOperation({ summary: 'Change Password' })
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
   @Post('/change-password')
   async changePassword(
@@ -91,6 +100,7 @@ export class AuthController {
   @UseGuards(AuthGuard)
   @ApiOperation({ summary: 'Generate Api Key' })
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @Post('/api-keys')
   async generateApiKey(@Request() req) {
     const { apiKey, message } = await this.authService.generateApiKey(req.user)
@@ -107,6 +117,7 @@ export class AuthController {
       'Filter keys: active (default), revoked only, or all (legacy full list)',
   })
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @Get('/api-keys')
   async getApiKey(
     @Request() req,
@@ -119,6 +130,7 @@ export class AuthController {
   @UseGuards(AuthGuard, CanModifyApiKey)
   @ApiOperation({ summary: 'Delete Api Key' })
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @HttpCode(HttpStatus.OK)
   @Delete('/api-keys/:id')
   async deleteApiKey(@Param() params) {
@@ -129,6 +141,7 @@ export class AuthController {
   @UseGuards(AuthGuard, CanModifyApiKey)
   @ApiOperation({ summary: 'Revoke Api Key' })
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @HttpCode(HttpStatus.OK)
   @Post('/api-keys/:id/revoke')
   async revokeApiKey(@Param() params) {
@@ -139,6 +152,7 @@ export class AuthController {
   @UseGuards(AuthGuard, CanModifyApiKey)
   @ApiOperation({ summary: 'Rename Api Key' })
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @HttpCode(HttpStatus.OK)
   @Patch('/api-keys/:id/rename')
   async renameApiKey(@Param() params, @Body() input: { name: string }) {
@@ -148,6 +162,7 @@ export class AuthController {
 
   @ApiOperation({ summary: 'Update dashboard onboarding progress' })
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
   @Patch('/onboarding')
   async updateOnboarding(
@@ -176,6 +191,7 @@ export class AuthController {
   @ApiOperation({ summary: 'Send Email Verification Code' })
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
   @Post('/send-email-verification-email')
   async sendEmailVerificationEmail(@Request() req) {

--- a/api/src/billing/billing.controller.ts
+++ b/api/src/billing/billing.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Post, Body, Get, UseGuards, Request } from '@nestjs/common'
 import { BillingService } from './billing.service'
 import { AuthGuard } from 'src/auth/guards/auth.guard'
-import { ApiTags, ApiBearerAuth } from '@nestjs/swagger'
+import { ApiTags, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger'
 import {
   ChangePlanInputDTO,
   ChangePlanResponseDTO,
@@ -13,6 +13,7 @@ import { BillingNotificationsService } from './billing-notifications.service'
 
 @ApiTags('billing')
 @ApiBearerAuth()
+@ApiSecurity('x-api-key')
 @Controller('billing')
 export class BillingController {
   constructor(

--- a/api/src/gateway/gateway.controller.ts
+++ b/api/src/gateway/gateway.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiOperation,
   ApiQuery,
   ApiResponse,
+  ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger'
 import { AuthGuard } from '../auth/guards/auth.guard'
@@ -34,6 +35,7 @@ import { CanModifyDevice } from './guards/can-modify-device.guard'
 
 @ApiTags('gateway')
 @ApiBearerAuth()
+@ApiSecurity('x-api-key')
 @Controller('gateway')
 export class GatewayController {
   constructor(private readonly gatewayService: GatewayService) {}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -41,11 +41,14 @@ async function bootstrap() {
     .setDescription('TextBee - Android SMS Gateway API Docs')
     .setVersion('1.0')
     .addBearerAuth()
-    .addApiKey({
-      type: 'apiKey',
-      name: 'x-api-key',
-      in: 'header',
-    })
+    .addApiKey(
+      {
+        type: 'apiKey',
+        name: 'x-api-key',
+        in: 'header',
+      },
+      'x-api-key',
+    )
     .build()
   const document = SwaggerModule.createDocument(app, config)
   SwaggerModule.setup('', app, document, {

--- a/api/src/support/support.controller.ts
+++ b/api/src/support/support.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common'
+import { ApiBearerAuth, ApiSecurity } from '@nestjs/swagger'
 import {
   CreateSupportMessageDto,
   SupportCategory,
@@ -16,6 +17,8 @@ export class SupportController {
     private readonly turnstileService: TurnstileService,
   ) {}
 
+  @ApiBearerAuth()
+  @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
   @Post('customer-support')
   async createSupportMessage(
@@ -37,6 +40,7 @@ export class SupportController {
     return this.supportService.createSupportMessage(createSupportMessageDto)
   }
 
+  @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Post('request-account-deletion')
   async requestAccountDeletion(

--- a/api/src/webhook/webhook.controller.ts
+++ b/api/src/webhook/webhook.controller.ts
@@ -11,12 +11,13 @@ import {
   Query,
 } from '@nestjs/common'
 import { WebhookService } from './webhook.service'
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
+import { ApiBearerAuth, ApiSecurity, ApiTags } from '@nestjs/swagger'
 import { CreateWebhookDto, UpdateWebhookDto } from './webhook.dto'
 import { AuthGuard } from 'src/auth/guards/auth.guard'
 
 @ApiTags('webhooks')
 @ApiBearerAuth()
+@ApiSecurity('x-api-key')
 @Controller('webhooks')
 export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}


### PR DESCRIPTION
Fixes #154, closes #258.

## Root cause

`main.ts` registered the API key scheme via `.addApiKey({...})` without a name, so it ended up in the OpenAPI doc under the default name `api_key`, and no operation ever referenced it (there was not a single `@ApiSecurity` in the repo, controllers only carried `@ApiBearerAuth`). A security scheme that no operation references means Swagger UI renders the Authorize box, stores the key, and never adds the header to any request. That is exactly the behavior reported in #154, and #258 has the full write-up.

## Changes

- Name the scheme so it registers as `securitySchemes['x-api-key']`: `.addApiKey({ type: 'apiKey', name: 'x-api-key', in: 'header' }, 'x-api-key')`
- Add `@ApiSecurity('x-api-key')` to every route guarded by `AuthGuard` (which accepts either a Bearer JWT or an x-api-key), mirroring the existing `@ApiBearerAuth` placement:
  - class-level on `GatewayController`, `WebhookController`, `BillingController`
  - per-route on `AuthController` (only the guarded routes; login/register/reset stay public, and `verify-email` keeps bearer only since it has no guard)
  - `SupportController` had no swagger auth annotations at all, so `customer-support` gets both decorators and `request-account-deletion` (JwtAuthGuard) gets `@ApiBearerAuth` only

## Verification

- `pnpm build` passes, and all 73 auth-related unit tests pass
- Inspected the compiled decorator metadata: every guarded operation now carries `[{"x-api-key":[]},{"bearer":[]}]`, public routes are unchanged
- To see it live: open Swagger UI, click Authorize, enter an API key, fire any gateway request and watch the `x-api-key` header go out in devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation for authenticated endpoints across authentication, billing, gateway, support, and webhook services.
  * Clearly documented API-key and bearer-token security requirements in the interactive API reference.
  * Updated the API-key security scheme so references display consistently throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->