### PR TITLE
fix: invalidate message list and stats after sending SMS

### DIFF
--- a/web/app/(app)/dashboard/(components)/bulk-send/use-bulk-send.ts
+++ b/web/app/(app)/dashboard/(components)/bulk-send/use-bulk-send.ts
@@ -3,10 +3,10 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useDropzone, type FileRejection } from 'react-dropzone'
 import Papa from 'papaparse'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import httpBrowserClient from '@/lib/httpBrowserClient'
 import { ApiEndpoints } from '@/config/api'
-import { useDevices, useSubscription } from '@/lib/api'
+import { invalidateAfterSend, useDevices, useSubscription } from '@/lib/api'
 import { getSegmentInfo } from '@/lib/sms'
 import {
   buildRecipientPlan,
@@ -34,6 +34,7 @@ export function useBulkSend() {
   const [fileWarning, setFileWarning] = useState<string | null>(null)
   const templateRef = useRef<HTMLTextAreaElement>(null)
 
+  const queryClient = useQueryClient()
   const { data: devices } = useDevices()
   const { data: subscription, isPending: subscriptionPending } =
     useSubscription()
@@ -214,6 +215,11 @@ export function useBulkSend() {
         ApiEndpoints.gateway.sendBulkSMS(deviceId!),
         { messageTemplate: template, messages }
       )
+    },
+    // A campaign moves the quota bar the most, so it invalidates the same keys
+    // as a single send.
+    onSuccess: () => {
+      if (deviceId) invalidateAfterSend(queryClient, deviceId)
     },
   })
 

--- a/web/lib/api/cache-invalidation.test.tsx
+++ b/web/lib/api/cache-invalidation.test.tsx
@@ -1,5 +1,12 @@
-import { describe, expect, it, beforeEach } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { QueryClient } from '@tanstack/react-query'
@@ -8,8 +15,10 @@ import { TestProviders } from '@/test/render'
 import { API_BASE_URL, mockUser } from '@/test/fixtures'
 import { ApiEndpoints } from '@/config/api'
 import { queryKeys } from './query-keys'
+import { useSendSms } from './hooks'
 import VerifyEmailAlert from '@/app/(app)/dashboard/(components)/alerts/verify-email-alert'
 import GenerateApiKey from '@/app/(app)/dashboard/(components)/api-keys/generate-api-key'
+import { useBulkSend } from '@/app/(app)/dashboard/(components)/bulk-send/use-bulk-send'
 
 const url = (path: string) => `${API_BASE_URL}${path.split('?')[0]}`
 
@@ -109,5 +118,111 @@ describe('cache invalidation', () => {
         'the dashboard stats must be invalidated'
       ).toBe(true)
     })
+  })
+
+  // Regression for #261. useSendSms and the bulk sender invalidated nothing, so
+  // a sent message never appeared in the history behind the composer and the
+  // quota bar sat still: with staleTime 60s and refetchOnWindowFocus off,
+  // nothing corrected them for a minute.
+  const deviceId = 'device-1'
+
+  // Primed under the filtered key the message list actually uses, so this also
+  // covers the prefix match: deviceMessages(deviceId) has to reach
+  // deviceMessages(deviceId, filters).
+  const primeSendCaches = (queryClient: QueryClient) => {
+    queryClient.setQueryData(
+      queryKeys.deviceMessages(deviceId, { type: 'all', page: 1, limit: 20 }),
+      { data: [] }
+    )
+    queryClient.setQueryData(queryKeys.stats, { sentSMSCount: 0 })
+    queryClient.setQueryData(queryKeys.subscription, { usage: {} })
+  }
+
+  // Asserted on the keys handed to invalidateQueries rather than on
+  // state.isInvalidated: a key with a live observer refetches immediately and
+  // clears its own invalidated flag, so the flag is only readable for keys
+  // nothing is currently watching (useBulkSend watches the subscription).
+  const recordInvalidations = (queryClient: QueryClient) => {
+    const spy = vi.spyOn(queryClient, 'invalidateQueries')
+    return () =>
+      spy.mock.calls.map(([filters]) => JSON.stringify(filters?.queryKey))
+  }
+
+  const expectSendKeysInvalidated = (invalidatedKeys: () => string[]) =>
+    waitFor(() => {
+      const keys = invalidatedKeys()
+      expect(keys, 'the message list must be invalidated').toContain(
+        JSON.stringify(queryKeys.deviceMessages(deviceId))
+      )
+      expect(keys, 'the dashboard stats must be invalidated').toContain(
+        JSON.stringify(queryKeys.stats)
+      )
+      expect(keys, 'the subscription quota must be invalidated').toContain(
+        JSON.stringify(queryKeys.subscription)
+      )
+    })
+
+  const hookWrapper = (queryClient: QueryClient) => {
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TestProviders queryClient={queryClient}>{children}</TestProviders>
+    )
+    Wrapper.displayName = 'HookWrapper'
+    return Wrapper
+  }
+
+  it('sending an SMS refreshes the message list, the stats and the quota', async () => {
+    server.use(
+      http.post(url(ApiEndpoints.gateway.sendSMS(deviceId)), () =>
+        HttpResponse.json({ data: { success: true } })
+      )
+    )
+
+    primeSendCaches(queryClient)
+    const invalidatedKeys = recordInvalidations(queryClient)
+
+    const { result } = renderHook(() => useSendSms(), {
+      wrapper: hookWrapper(queryClient),
+    })
+
+    act(() => {
+      result.current.mutate({
+        deviceId,
+        recipients: ['+251900000000'],
+        message: 'hi',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    await expectSendKeysInvalidated(invalidatedKeys)
+
+    // Nothing observes the message list here, so its flag survives to be read:
+    // proof the device-level key reaches the filtered entry the list caches
+    // under.
+    expect(
+      queryClient.getQueryState(
+        queryKeys.deviceMessages(deviceId, { type: 'all', page: 1, limit: 20 })
+      )?.isInvalidated
+    ).toBe(true)
+  })
+
+  it('a bulk send refreshes the same caches as a single send', async () => {
+    server.use(
+      http.post(url(ApiEndpoints.gateway.sendBulkSMS(deviceId)), () =>
+        HttpResponse.json({ data: { success: true } })
+      )
+    )
+
+    primeSendCaches(queryClient)
+    const invalidatedKeys = recordInvalidations(queryClient)
+
+    const { result } = renderHook(() => useBulkSend(), {
+      wrapper: hookWrapper(queryClient),
+    })
+
+    act(() => result.current.setDeviceId(deviceId))
+    act(() => result.current.sendBulk())
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    await expectSendKeysInvalidated(invalidatedKeys)
   })
 })

--- a/web/lib/api/hooks.ts
+++ b/web/lib/api/hooks.ts
@@ -379,10 +379,17 @@ export type SendSmsPayload = {
 }
 
 export function useSendSms() {
+  const queryClient = useQueryClient()
   return useMutation({
     mutationKey: ['send-sms'],
     mutationFn: (data: SendSmsPayload) =>
       httpBrowserClient.post(ApiEndpoints.gateway.sendSMS(data.deviceId), data),
+    onSuccess: (_, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.deviceMessages(variables.deviceId),
+      })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.stats })
+    },
   })
 }
 

--- a/web/lib/api/hooks.ts
+++ b/web/lib/api/hooks.ts
@@ -2,6 +2,7 @@ import {
   useMutation,
   useQuery,
   useQueryClient,
+  type QueryClient,
   type UseMutationOptions,
   type UseQueryOptions,
 } from '@tanstack/react-query'
@@ -378,18 +379,29 @@ export type SendSmsPayload = {
   simSubscriptionId?: number
 }
 
+// A send adds to the device's history and consumes quota, so it has to refresh
+// the message list, the dashboard stats and the subscription usage. Exported
+// because the bulk sender posts its own mutation and must invalidate the same
+// three keys (issue #261).
+export function invalidateAfterSend(
+  queryClient: QueryClient,
+  deviceId: string
+) {
+  void queryClient.invalidateQueries({
+    queryKey: queryKeys.deviceMessages(deviceId),
+  })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.stats })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.subscription })
+}
+
 export function useSendSms() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationKey: ['send-sms'],
     mutationFn: (data: SendSmsPayload) =>
       httpBrowserClient.post(ApiEndpoints.gateway.sendSMS(data.deviceId), data),
-    onSuccess: (_, variables) => {
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.deviceMessages(variables.deviceId),
-      })
-      void queryClient.invalidateQueries({ queryKey: queryKeys.stats })
-    },
+    onSuccess: (_, variables) =>
+      invalidateAfterSend(queryClient, variables.deviceId),
   })
 }
 


### PR DESCRIPTION
## Summary

Fixes #261 — The `useSendSms` mutation was the only mutation in `hooks.ts` that did not invalidate any queries on success. After sending an SMS the message history dialog and the dashboard usage stats remained stale until the next manual page refresh.

## Changes

### `web/lib/api/hooks.ts`
- Called `useQueryClient()` inside `useSendSms` (matching the pattern used by every other mutation in the file)
- Added `queryClient.invalidateQueries` for `deviceMessages` on success, so the conversation history dialog shows the just-sent message
- Added `queryClient.invalidateQueries` for `stats` on success, so the dashboard usage counters update

## Testing

1. Open the message history dialog for a device
2. Send an SMS
3. Confirm the new message appears in the history without manual refresh
4. Confirm the dashboard SMS usage counter updates without manual refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message history, gateway statistics, and subscription usage now refresh automatically after sending SMS messages.
  * Bulk sends now also refresh related device information, ensuring current message and usage data is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->