### PR TITLE
fix(android): key SMS status work by smsId to stop collision drops (#…

### DIFF
--- a/android/app/src/main/java/com/vernu/sms/workers/SMSStatusUpdateWorker.kt
+++ b/android/app/src/main/java/com/vernu/sms/workers/SMSStatusUpdateWorker.kt
@@ -7,6 +7,7 @@ import com.google.gson.Gson
 import com.vernu.sms.ApiManager
 import com.vernu.sms.dtos.SMSDTO
 import com.vernu.sms.dtos.SMSForwardResponseDTO
+import com.google.gson.JsonSyntaxException
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
@@ -18,14 +19,12 @@ class SMSStatusUpdateWorker(context: Context, workerParams: WorkerParameters) : 
         const val KEY_DEVICE_ID = "device_id"
         const val KEY_API_KEY = "api_key"
         const val KEY_SMS_DTO = "sms_dto"
-        const val KEY_RETRY_COUNT = "retry_count"
 
         fun enqueueWork(context: Context, deviceId: String, apiKey: String, smsDTO: SMSDTO) {
             val inputData = Data.Builder()
                 .putString(KEY_DEVICE_ID, deviceId)
                 .putString(KEY_API_KEY, apiKey)
                 .putString(KEY_SMS_DTO, Gson().toJson(smsDTO))
-                .putInt(KEY_RETRY_COUNT, 0)
                 .build()
 
             val constraints = Constraints.Builder()
@@ -38,9 +37,9 @@ class SMSStatusUpdateWorker(context: Context, workerParams: WorkerParameters) : 
                 .setInputData(inputData)
                 .build()
 
-            val uniqueWorkName = "sms_status_${smsDTO.status}_${System.currentTimeMillis()}"
+            val uniqueWorkName = "sms_status_${smsDTO.smsId ?: System.currentTimeMillis()}_${smsDTO.status}"
             WorkManager.getInstance(context)
-                .beginUniqueWork(uniqueWorkName, ExistingWorkPolicy.REPLACE, workRequest)
+                .beginUniqueWork(uniqueWorkName, ExistingWorkPolicy.KEEP, workRequest)
                 .enqueue()
 
             Log.d(TAG, "Work enqueued for SMS status update - ID: ${smsDTO.smsId}")
@@ -51,14 +50,13 @@ class SMSStatusUpdateWorker(context: Context, workerParams: WorkerParameters) : 
         val deviceId = inputData.getString(KEY_DEVICE_ID)
         val apiKey = inputData.getString(KEY_API_KEY)
         val smsDtoJson = inputData.getString(KEY_SMS_DTO)
-        val retryCount = inputData.getInt(KEY_RETRY_COUNT, 0)
 
         if (deviceId == null || apiKey == null || smsDtoJson == null) {
             Log.e(TAG, "Missing required parameters")
             return Result.failure()
         }
 
-        if (retryCount >= MAX_RETRIES) {
+        if (runAttemptCount >= MAX_RETRIES) {
             Log.e(TAG, "Maximum retry count reached for SMS status update")
             return Result.failure()
         }
@@ -76,6 +74,9 @@ class SMSStatusUpdateWorker(context: Context, workerParams: WorkerParameters) : 
             }
         } catch (e: IOException) {
             Log.e(TAG, "API call failed: ${e.message}")
+            Result.retry()
+        } catch (e: JsonSyntaxException) {
+            Log.e(TAG, "Malformed response body: ${e.message}")
             Result.retry()
         }
     }


### PR DESCRIPTION
Fixes #254

SMSStatusUpdateWorker keyed its unique-work name on status + current
millisecond with REPLACE, so same-millisecond reports (bulk sends,
multipart SMS parts) collided and the pending one was cancelled silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS status update reliability by using managed retry attempts.
  * Prevented duplicate status-update work from replacing existing tasks.
  * Added recovery handling for malformed status data, allowing updates to retry safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->