### PR TITLE
fix: wire email verification button to existing API hook (Fixes #282)

### DIFF
--- a/web/app/(app)/dashboard/(components)/account/edit-profile-form.tsx
+++ b/web/app/(app)/dashboard/(components)/account/edit-profile-form.tsx
@@ -10,7 +10,7 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useToast } from '@/hooks/use-toast'
-import { useCurrentUser, useUpdateProfile } from '@/lib/api'
+import { useCurrentUser, useUpdateProfile, useSendEmailVerification } from '@/lib/api'
 import { Spinner } from '@/components/ui/spinner'
 import { useSession } from 'next-auth/react'
 
@@ -44,8 +44,23 @@ export default function EditProfileForm() {
     },
   })
 
+  const sendEmailVerification = useSendEmailVerification({
+    onSuccess: () => {
+      toast({
+        title: 'Verification email sent!',
+        description: 'Check your inbox for the verification link.',
+      })
+    },
+    onError: () => {
+      toast({
+        title: 'Failed to send verification email',
+        variant: 'destructive',
+      })
+    },
+  })
+
   const handleVerifyEmail = () => {
-    // TODO: Implement email verification
+    sendEmailVerification.mutate()
   }
 
   const {
@@ -122,9 +137,9 @@ export default function EditProfileForm() {
               type='button'
               variant='outline'
               onClick={handleVerifyEmail}
-              disabled={true}
+              disabled={sendEmailVerification.isPending}
             >
-              {isUpdatingProfile ? (
+              {sendEmailVerification.isPending ? (
                 <Loader2 className='h-4 w-4 animate-spin' />
               ) : (
                 <Mail className='h-4 w-4 mr-2' />


### PR DESCRIPTION
## Summary

Fixes #282 — The email Verify button on the profile page was a hardcoded disabled no-op with an empty handler.

## Changes

1. Wired `useSendEmailVerification()` — the existing hook that posts to the resend-verification endpoint is now called when the Verify button is clicked.
2. Enabled the button — removed `disabled={true}` and replaced it with the mutation pending state.
3. Fixed the spinner — the button spinner was driven by `isUpdatingProfile` (the unrelated profile-save mutation). Now it correctly reflects the verification email send state.
4. Added feedback — success/error toasts so the user knows whether the email was sent.

The backend `useSendEmailVerification()` hook already existed in `web/lib/api/hooks.ts` — it was just never wired to this button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email verification from the profile settings.
  * Added success and error notifications for verification requests.
  * Verification controls now show progress and prevent duplicate submissions while processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->