### PR TITLE
fix(api): validate deviceId before ObjectId conversion

### DIFF
--- a/api/src/webhook/webhook.service.ts
+++ b/api/src/webhook/webhook.service.ts
@@ -217,6 +217,13 @@ export class WebhookService {
     }
 
     if (deviceId) {
+      if (!mongoose.Types.ObjectId.isValid(deviceId)) {
+        throw new HttpException(
+          'Invalid deviceId',
+          HttpStatus.BAD_REQUEST,
+        )
+      }
+
       commonPipeline.push({
         $match: {
           'deviceData._id': new mongoose.Types.ObjectId(deviceId),


### PR DESCRIPTION
## Summary

This PR fixes an issue where an invalid `deviceId` query parameter caused a `500 Internal Server Error`.

### Changes
- Validate `deviceId` using `mongoose.Types.ObjectId.isValid()`.
- Return `400 Bad Request` with the message `Invalid deviceId` when the value is invalid.
- Preserve the existing behavior for valid `deviceId` values.

### Verification
- ✅ `pnpm test` (167 tests passed)
- ✅ `pnpm build`

Fixes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for device identifiers when retrieving webhook notifications.
  * Invalid device identifiers now return a clear bad-request error instead of causing processing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->