### PR TITLE
fix(api): await SMS batch status update

### DIFF
--- a/api/src/gateway/queue/sms-queue.processor.spec.ts
+++ b/api/src/gateway/queue/sms-queue.processor.spec.ts
@@ -1,0 +1,76 @@
+import { Job } from 'bull'
+import * as firebaseAdmin from 'firebase-admin'
+import { SmsQueueProcessor } from './sms-queue.processor'
+
+jest.mock('firebase-admin', () => ({
+  messaging: jest.fn().mockReturnValue({
+    sendEach: jest.fn(),
+  }),
+}))
+
+describe('SmsQueueProcessor', () => {
+  it('waits for the batch to enter processing before sending messages', async () => {
+    let releaseProcessing: (() => void) | undefined
+    const processingComplete = new Promise<void>((resolve) => {
+      releaseProcessing = resolve
+    })
+    const sendEach = jest
+      .spyOn(firebaseAdmin.messaging(), 'sendEach')
+      .mockResolvedValue({
+        responses: [],
+        successCount: 0,
+        failureCount: 0,
+      })
+
+    const smsBatchModel = {
+      findByIdAndUpdate: jest.fn((_, update, options) => {
+        if (update.$set?.status === 'processing') {
+          return { exec: () => processingComplete }
+        }
+        if (options?.returnDocument === 'after') {
+          return Promise.resolve({
+            successCount: 0,
+            failureCount: 0,
+            recipientCount: 1,
+          })
+        }
+        return Promise.resolve({})
+      }),
+    }
+    const deviceModel = {
+      findById: jest.fn(() => ({
+        populate: () => ({ exec: jest.fn().mockResolvedValue(null) }),
+      })),
+      findByIdAndUpdate: jest.fn(() => ({
+        exec: jest.fn().mockResolvedValue({}),
+      })),
+    }
+    const smsModel = {
+      updateMany: jest.fn(),
+      find: jest.fn(),
+    }
+    const webhookService = { deliverNotification: jest.fn() }
+    const processor = new SmsQueueProcessor(
+      deviceModel as any,
+      smsModel as any,
+      smsBatchModel as any,
+      webhookService as any,
+    )
+
+    const handling = processor.handleSendSms({
+      id: 'job-1',
+      data: { deviceId: 'device-1', fcmMessages: [], smsBatchId: 'batch-1' },
+    } as unknown as Job<any>)
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(sendEach).not.toHaveBeenCalled()
+
+    releaseProcessing!()
+    await handling
+
+    expect(smsBatchModel.findByIdAndUpdate).toHaveBeenCalledWith('batch-1', {
+      $set: { status: 'processing' },
+    })
+    expect(sendEach).toHaveBeenCalledWith([])
+  })
+})

--- a/api/src/gateway/queue/sms-queue.processor.ts
+++ b/api/src/gateway/queue/sms-queue.processor.ts
@@ -69,18 +69,11 @@ export class SmsQueueProcessor {
     }
 
     try {
-      this.smsBatchModel
+      await this.smsBatchModel
         .findByIdAndUpdate(smsBatchId, {
           $set: { status: 'processing' },
         })
         .exec()
-        .catch((error) => {
-          this.logger.error(
-            `Failed to update sms batch status to processing ${smsBatchId}`,
-            error,
-          )
-          throw error
-        })
 
       const response = await firebaseAdmin.messaging().sendEach(fcmMessages)
 


### PR DESCRIPTION
## Summary

The SMS queue processor started the FCM send before awaiting the batch transition to `processing`. If that update failed, its rejected promise could escape the outer error handler and the batch stayed `pending` until the timeout task changed it to `unknown`.

This change awaits the status update so failures enter the existing processing error path, and removes the nested rethrow that created an unhandled rejection. A focused unit test proves the FCM send does not begin until the status update resolves and verifies the `processing` transition.

Closes #279.

## Validation

- `pnpm exec jest --runInBand src/gateway/queue/sms-queue.processor.spec.ts`
- `pnpm exec jest --runInBand` (14 suites, 162 tests passed)
- `pnpm exec prettier --check src/gateway/queue/sms-queue.processor.spec.ts`
- `git diff --check`
