### PR TITLE
Fix webhook history error state

### DIFF
--- a/web/app/(app)/dashboard/(components)/webhooks-history/index.tsx
+++ b/web/app/(app)/dashboard/(components)/webhooks-history/index.tsx
@@ -65,7 +65,6 @@ export default function WebhooksHistory() {
             <ErrorState
               error={error}
               title="Couldn't load webhook deliveries"
-              icon={History}
               onRetry={() => refetch()}
             />
           ) : (

--- a/web/app/(app)/dashboard/(components)/webhooks-history/index.tsx
+++ b/web/app/(app)/dashboard/(components)/webhooks-history/index.tsx
@@ -2,6 +2,7 @@
 
 import WebhookDeliveriesTable from './deliveries-table'
 import NumberedPagination from '@/components/shared/numbered-pagination'
+import ErrorState from '@/components/shared/error-state'
 import {
   useDevices,
   useWebhookNotifications,
@@ -28,8 +29,12 @@ export default function WebhooksHistory() {
   const { data: devices } = useDevices()
   const { data: webhooks } = useWebhooks()
 
-  const { data: webhookNotifications, isLoading: isLoadingNotifications } =
-    useWebhookNotifications({
+  const { 
+    data: webhookNotifications, 
+    isLoading: isLoadingNotifications,
+    error,
+    refetch,
+   } = useWebhookNotifications({
       eventType: eventType === 'all' ? '' : eventType,
       status: status === 'all' ? '' : status,
       deviceId: currentDevice === 'all' ? '' : currentDevice,
@@ -41,7 +46,6 @@ export default function WebhooksHistory() {
     })
 
   const totalPages = webhookNotifications?.data?.meta?.totalPages ?? 1
-
   return (
     <div className='flex flex-col gap-y-4'>
       <div className='bg-card rounded-lg shadow-sm border border-border p-4 mb-4'>
@@ -53,7 +57,17 @@ export default function WebhooksHistory() {
           />
 
           {isLoadingNotifications ? (
-            <WebhookDeliveriesTable data={[]} isLoading={true} />
+            <WebhookDeliveriesTable
+              data={[]}
+              isLoading={true}
+            />
+          ) : error ? (
+            <ErrorState
+              error={error}
+              title="Couldn't load webhook deliveries"
+              icon={History}
+              onRetry={() => refetch()}
+            />
           ) : (
             <WebhookDeliveriesTable
               data={webhookNotifications?.data?.data || []}


### PR DESCRIPTION
## Summary

Fixes #277.

### Changes

- Render the shared `ErrorState` when loading webhook delivery history fails.
- Preserve the existing loading state.
- Prevent failed requests from falling through to the table's misleading "No results." state.
- Follow the existing error handling pattern used in other dashboard components by reusing `ErrorState` and `refetch()`.

### Testing

- [x] Ran `pnpm lint` (0 errors; existing project warnings only).
- [x] Verified loading behavior is unchanged.
- [x] Verified failed requests now render `ErrorState` instead of "No results."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear error state when webhook history fails to load.
  * Users can retry loading webhook history directly from the error message.
  * Preserved existing loading and successfully loaded table views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->