### PR TITLE
Keep in-app upgrade links pointing straight at checkout

### DIFF
--- a/web/app/(app)/checkout/[planName]/page.tsx
+++ b/web/app/(app)/checkout/[planName]/page.tsx
@@ -12,14 +12,15 @@ import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { Badge } from '@/components/ui/badge'
 import {
+  MONEY_BACK_DAYS,
   findPlanTier,
   formatPlanPrice,
   monthlyEquivalent,
   yearlySavingPercent,
+  type BillingInterval,
 } from '@/lib/plans'
+import { Routes } from '@/config/routes'
 import { cn } from '@/lib/utils'
-
-type BillingInterval = 'monthly' | 'yearly'
 
 interface PlanChangePreview {
   currentPlan: string
@@ -32,6 +33,26 @@ interface PlanChangePreview {
 
 const formatPlan = (plan: string, interval: string) =>
   `${plan.charAt(0).toUpperCase() + plan.slice(1)} (${interval})`
+
+/**
+ * The refund window differs by interval, so the reassurance shown at the point
+ * of payment has to follow the interval rather than quote one number.
+ */
+function MoneyBackNote({ interval }: { interval: BillingInterval }) {
+  return (
+    <p className='text-center text-xs text-muted-foreground'>
+      {MONEY_BACK_DAYS[interval]}-day money-back guarantee.{' '}
+      <Link
+        href={Routes.refundPolicy}
+        target='_blank'
+        rel='noopener noreferrer'
+        className='underline underline-offset-2'
+      >
+        Refund policy
+      </Link>
+    </p>
+  )
+}
 
 /** Frames every state on this page so they share one width and one elevation. */
 function CheckoutShell({ children }: { children: React.ReactNode }) {
@@ -245,12 +266,11 @@ export default function CheckoutPage({
   // an interval in the URL always redirects, so show progress rather than
   // flashing the chooser before the effect fires
   if (isSubmitting || urlInterval !== null) {
-    const intervalLabel = (urlInterval ?? selected) === 'yearly' ? 'yearly' : 'monthly'
+    const activeInterval: BillingInterval =
+      (urlInterval ?? selected) === 'yearly' ? 'yearly' : 'monthly'
     const price =
       tier &&
-      ((urlInterval ?? selected) === 'yearly'
-        ? tier.yearlyPrice
-        : tier.monthlyPrice)
+      (activeInterval === 'yearly' ? tier.yearlyPrice : tier.monthlyPrice)
 
     return (
       <CheckoutShell>
@@ -260,7 +280,7 @@ export default function CheckoutPage({
           <div>
             <h1 className='text-lg font-semibold'>
               {tier
-                ? `Setting up your ${tier.name} ${intervalLabel} checkout`
+                ? `Setting up your ${tier.name} ${activeInterval} checkout`
                 : 'Setting up your checkout'}
             </h1>
             <p className='mt-2 text-sm text-muted-foreground'>
@@ -271,7 +291,7 @@ export default function CheckoutPage({
 
           {tier && price !== undefined && (
             <p className='text-sm font-medium tabular-nums'>
-              {tier.name}, {intervalLabel}, {formatPlanPrice(price)}
+              {tier.name}, {activeInterval}, {formatPlanPrice(price)}
             </p>
           )}
 
@@ -369,6 +389,10 @@ export default function CheckoutPage({
       <p className='mt-3 text-center text-xs text-muted-foreground'>
         Cancel anytime, keep access until the end of your billing period.
       </p>
+
+      <div className='mt-1'>
+        <MoneyBackNote interval={selected} />
+      </div>
     </CheckoutShell>
   )
 }

--- a/web/app/(app)/dashboard/(components)/alerts/upgrade-to-pro-alert.tsx
+++ b/web/app/(app)/dashboard/(components)/alerts/upgrade-to-pro-alert.tsx
@@ -1,6 +1,8 @@
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { useSubscription } from '@/lib/api'
+import { checkoutPath } from '@/lib/plans'
+import { Routes } from '@/config/routes'
 import Link from 'next/link'
 import { useMemo } from 'react'
 
@@ -149,17 +151,24 @@ export default function UpgradeToProAlert() {
               asChild
               className={`${scaleAlertConfig.buttonColor} text-xs md:text-sm`}
             >
-              <Link href={'/checkout/scale'}>
+              <Link href={checkoutPath('scale')}>
                 {scaleAlertConfig.buttonText}
               </Link>
             </Button>
+            {/* The dashboard has no pricing route; /#pricing was its own root. */}
             <Button
               variant='outline'
               size='sm'
               asChild
               className='bg-brand-600 text-white hover:bg-brand-700 text-xs md:text-sm'
             >
-              <Link href={'/#pricing'}>Learn More</Link>
+              <Link
+                href={`${Routes.landingPage}/pricing`}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                Learn More
+              </Link>
             </Button>
           </div>
         </AlertDescription>
@@ -187,8 +196,9 @@ export default function UpgradeToProAlert() {
             asChild
             className={`${alertConfig.buttonColor} text-xs md:text-sm`}
           >
-            <Link href={'/checkout/pro'}>{alertConfig.buttonText}</Link>
+            <Link href={checkoutPath('pro')}>{alertConfig.buttonText}</Link>
           </Button>
+          {/* The dashboard has no pricing route; /#pricing was its own root. */}
           {alertConfig.urgency === 'normal' && (
             <Button
               variant='outline'
@@ -196,7 +206,13 @@ export default function UpgradeToProAlert() {
               asChild
               className='bg-brand-600 text-white hover:bg-brand-700 text-xs md:text-sm'
             >
-              <Link href={'/#pricing'}>Learn More</Link>
+              <Link
+                href={`${Routes.landingPage}/pricing`}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                Learn More
+              </Link>
             </Button>
           )}
         </div>

--- a/web/app/(app)/dashboard/(components)/billing/subscription-info.test.tsx
+++ b/web/app/(app)/dashboard/(components)/billing/subscription-info.test.tsx
@@ -102,7 +102,7 @@ describe('SubscriptionInfo', () => {
       render(<SubscriptionInfo />)
       expect(
         screen.getByRole('link', { name: /Upgrade to Pro/ })
-      ).toHaveAttribute('href', '/checkout/pro')
+      ).toHaveAttribute('href', '/checkout/pro?billingInterval=monthly')
     })
 
     it('still shows the plan limits', () => {
@@ -135,7 +135,7 @@ describe('SubscriptionInfo', () => {
 
       expect(
         screen.getByRole('link', { name: /Upgrade to Scale/ })
-      ).toHaveAttribute('href', '/checkout/scale')
+      ).toHaveAttribute('href', '/checkout/scale?billingInterval=monthly')
       expect(
         screen.queryByRole('link', { name: /Upgrade to Pro/ })
       ).not.toBeInTheDocument()

--- a/web/app/(app)/dashboard/(components)/billing/subscription-info.tsx
+++ b/web/app/(app)/dashboard/(components)/billing/subscription-info.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/lib/status'
 import { deriveUsage } from '@/lib/usage'
 import { billingPriceLabel, deriveBillingState } from '@/lib/billing'
-import { formatPlanPrice } from '@/lib/plans'
+import { checkoutPath, formatPlanPrice } from '@/lib/plans'
 import { Routes } from '@/config/routes'
 import { polarCustomerPortalRequestUrl } from '@/config/external-links'
 import Link from 'next/link'
@@ -416,7 +416,7 @@ export default function SubscriptionInfo() {
         <div className='mt-4 flex flex-wrap items-center gap-2'>
           {billing.upgradeTier && (
             <Button size='sm' asChild>
-              <Link href={`/checkout/${billing.upgradeTier.id}`}>
+              <Link href={checkoutPath(billing.upgradeTier.id)}>
                 Upgrade to {billing.upgradeTier.name}
                 <ArrowRight className='ml-1 h-3.5 w-3.5' aria-hidden />
               </Link>

--- a/web/app/(app)/dashboard/(components)/devices/device-list.tsx
+++ b/web/app/(app)/dashboard/(components)/devices/device-list.tsx
@@ -157,8 +157,15 @@ export default function DeviceList() {
                   )}
                 </p>
               </div>
+              {/* The dashboard has no /pricing route: this used to 404. */}
               <Button variant='outline' size='sm' asChild className='shrink-0'>
-                <Link href='/pricing'>Upgrade plan</Link>
+                <Link
+                  href={`${Routes.landingPage}/pricing`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  Upgrade plan
+                </Link>
               </Button>
             </div>
           )}

--- a/web/app/(app)/dashboard/(components)/get-started/plan-picker.test.tsx
+++ b/web/app/(app)/dashboard/(components)/get-started/plan-picker.test.tsx
@@ -31,25 +31,34 @@ describe('PlanPicker', () => {
     ).toEqual(['Free', 'Pro', 'Scale'])
   })
 
-  // The headline figure is the yearly per-month equivalent, so both it and the
-  // month-to-month price are pinned. A customer must never see a price we do
-  // not charge.
-  it('leads with the yearly per-month price', () => {
+  // The headline must be what the CTA charges. It used to be the yearly
+  // per-month equivalent, so a card reading "$8.33/month" billed $99.99.
+  it('leads with the price its CTA actually charges', () => {
     renderPicker()
 
-    expect(screen.getByText('$8.33')).toBeInTheDocument()
-    expect(screen.getByText('$25.00')).toBeInTheDocument()
+    expect(screen.getByText('$9.99')).toBeInTheDocument()
+    expect(screen.getByText('$29.99')).toBeInTheDocument()
+    expect(screen.queryByText('$8.33')).not.toBeInTheDocument()
   })
 
-  it('still shows what the monthly option costs', () => {
+  it('still offers the yearly alternative underneath', () => {
     renderPicker()
 
     expect(
-      screen.getByText('billed yearly at $99.99, or $9.99 monthly')
+      screen.getByText('or $8.33/month billed yearly at $99.99')
     ).toBeInTheDocument()
     expect(
-      screen.getByText('billed yearly at $299.99, or $29.99 monthly')
+      screen.getByText('or $25.00/month billed yearly at $299.99')
     ).toBeInTheDocument()
+  })
+
+  // The reassurance has to match the interval the CTA commits to.
+  it('quotes the refund window its CTA actually gives you', () => {
+    renderPicker()
+
+    expect(
+      screen.getAllByText(/7-day money-back guarantee/)
+    ).toHaveLength(2)
   })
 
   it('quotes the yearly saving on each paid tier', () => {
@@ -58,16 +67,18 @@ describe('PlanPicker', () => {
     expect(screen.getAllByText('Save 17% yearly')).toHaveLength(2)
   })
 
-  it('links each paid tier at its own checkout route', () => {
+  // Naming the interval is what makes checkout redirect straight to Polar
+  // instead of stopping on the chooser.
+  it('links each paid tier at its own checkout route, interval named', () => {
     renderPicker()
 
     expect(screen.getByRole('link', { name: /Upgrade to Pro/ })).toHaveAttribute(
       'href',
-      '/checkout/pro'
+      '/checkout/pro?billingInterval=monthly'
     )
     expect(
       screen.getByRole('link', { name: /Upgrade to Scale/ })
-    ).toHaveAttribute('href', '/checkout/scale')
+    ).toHaveAttribute('href', '/checkout/scale?billingInterval=monthly')
   })
 
   it('marks the subscribed tier as current and does not sell it again', () => {

--- a/web/app/(app)/dashboard/(components)/get-started/plan-picker.tsx
+++ b/web/app/(app)/dashboard/(components)/get-started/plan-picker.tsx
@@ -16,10 +16,12 @@ import { Check, ExternalLink } from 'lucide-react'
 import { Routes } from '@/config/routes'
 import { useSubscription } from '@/lib/api'
 import {
+  DEFAULT_CHECKOUT_INTERVAL,
+  MONEY_BACK_DAYS,
   PLAN_TIERS,
+  checkoutPath,
   formatPlanPrice,
   formatPriceCaption,
-  monthlyEquivalent,
   yearlySavingPercent,
   type PlanTier,
 } from '@/lib/plans'
@@ -45,7 +47,6 @@ function PlanCard({
 }) {
   const free = tier.monthlyPrice <= 0
   const highlight = tier.isPopular && !isCurrent
-  const perMonth = monthlyEquivalent(tier)
   const saving = yearlySavingPercent(tier)
 
   return (
@@ -74,8 +75,10 @@ function PlanCard({
 
         <div className='pt-2'>
           <div className='flex items-baseline gap-1'>
+            {/* The headline is what the CTA charges. Leading with the yearly
+                per-month equivalent meant a "$8.33/month" card billed $99.99. */}
             <span className='text-3xl font-semibold tabular-nums'>
-              {formatPlanPrice(perMonth ?? tier.monthlyPrice)}
+              {formatPlanPrice(tier.monthlyPrice)}
             </span>
             <span className='text-sm text-muted-foreground'>/month</span>
           </div>
@@ -129,9 +132,12 @@ function PlanCard({
             {/* above the button so every card's CTA lands on one baseline */}
             <p className='text-center text-xs text-muted-foreground'>
               Cancel anytime, keep access until the end of your billing period.
+              {' '}
+              {MONEY_BACK_DAYS[DEFAULT_CHECKOUT_INTERVAL]}-day money-back
+              guarantee.
             </p>
             <Button className='w-full' asChild>
-              <Link href={`/checkout/${tier.id}`}>Upgrade to {tier.name}</Link>
+              <Link href={checkoutPath(tier.id)}>Upgrade to {tier.name}</Link>
             </Button>
           </>
         )}

--- a/web/components/shared/rate-limit-error.tsx
+++ b/web/components/shared/rate-limit-error.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { AlertCircle } from 'lucide-react'
 import type { RateLimitErrorData } from '@/lib/utils/errorHandler'
+import { checkoutPath } from '@/lib/plans'
 
 interface RateLimitErrorProps {
   errorData?: RateLimitErrorData
@@ -28,7 +29,7 @@ export function RateLimitError({
         <p className="text-sm text-destructive">{message}</p>
         <div className="flex gap-2 flex-wrap">
           <Button asChild variant="default" size="sm">
-            <Link href="/checkout/pro">Upgrade Plan</Link>
+            <Link href={checkoutPath('pro')}>Upgrade Plan</Link>
           </Button>
           <p className="text-xs text-muted-foreground flex items-center">
             or wait for your limit to reset
@@ -46,7 +47,7 @@ export function RateLimitError({
         <p>{message}</p>
         <div className="flex gap-2 flex-wrap items-center">
           <Button asChild variant="outline" size="sm">
-            <Link href="/checkout/pro">Upgrade Plan</Link>
+            <Link href={checkoutPath('pro')}>Upgrade Plan</Link>
           </Button>
           <span className="text-xs text-muted-foreground">
             or wait for your limit to reset

--- a/web/e2e/checkout.spec.ts
+++ b/web/e2e/checkout.spec.ts
@@ -57,6 +57,28 @@ test.describe('checkout (mocked API, no real backend)', () => {
     await expect(page).toHaveURL(/polar-checkout-mock=1/)
   })
 
+  // Guards the regression where in-app CTAs omitted billingInterval, so
+  // clicking Upgrade stopped on the interval chooser instead of continuing to
+  // the payment page.
+  test('an in-app upgrade CTA goes straight to Polar', async ({
+    page,
+    context,
+  }) => {
+    await authenticate(context)
+    await mockApi(page)
+    await page.goto('/dashboard/account/billing')
+
+    const cta = page.getByRole('link', { name: /Upgrade to/ }).first()
+    await expect(cta).toHaveAttribute('href', /billingInterval=/)
+
+    await cta.click()
+
+    await expect(page).toHaveURL(/polar-checkout-mock=1/)
+    await expect(
+      page.getByRole('button', { name: 'Continue to checkout' })
+    ).toHaveCount(0)
+  })
+
   test.describe('when the URL names no interval', () => {
     test('asks instead of guessing, with yearly preselected', async ({
       page,
@@ -71,6 +93,24 @@ test.describe('checkout (mocked API, no real backend)', () => {
       await expect(
         page.getByRole('button', { name: 'Continue to checkout' })
       ).toBeVisible()
+    })
+
+    // The refund window differs by interval, so the note has to follow the
+    // selection rather than quote one number.
+    test('quotes the refund window for the selected interval', async ({
+      page,
+      context,
+    }) => {
+      await authenticate(context)
+      await mockApi(page)
+      await page.goto('/checkout/pro')
+
+      await expect(
+        page.getByText('14-day money-back guarantee')
+      ).toBeVisible()
+
+      await page.getByRole('radio', { name: /Monthly/ }).check()
+      await expect(page.getByText('7-day money-back guarantee')).toBeVisible()
     })
 
     test('posts nothing until the user confirms', async ({ page, context }) => {

--- a/web/lib/plans.test.ts
+++ b/web/lib/plans.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  MONEY_BACK_DAYS,
   PLAN_TIERS,
+  checkoutPath,
   findPlanTier,
   formatPlanPrice,
   formatPriceCaption,
@@ -90,15 +92,16 @@ describe('yearly pricing', () => {
     }
   })
 
-  // The picker prints a headline per-month figure, so its caption must not
-  // repeat it.
+  // The picker headlines the month-to-month price, so the caption carries the
+  // yearly alternative and must not repeat the headline.
   it('captions a headline price without repeating it', () => {
     expect(formatPriceCaption(pro)).toBe(
-      'billed yearly at $99.99, or $9.99 monthly'
+      'or $8.33/month billed yearly at $99.99'
     )
     expect(formatPriceCaption(scale)).toBe(
-      'billed yearly at $299.99, or $29.99 monthly'
+      'or $25.00/month billed yearly at $299.99'
     )
+    expect(formatPriceCaption(pro)).not.toContain('$9.99')
   })
 
   it('captions the free tier without quoting a price', () => {
@@ -107,19 +110,19 @@ describe('yearly pricing', () => {
 
   it('captions a paid tier that has no yearly option', () => {
     expect(formatPriceCaption({ ...pro, yearlyPrice: undefined })).toBe(
-      '$9.99 billed monthly'
+      'billed monthly'
     )
   })
 
   // The caption is the only place the yearly total is quoted, so it has to
-  // carry both figures.
-  it('quotes both the yearly total and the monthly price', () => {
+  // carry both the total and what it works out to per month.
+  it('quotes both the yearly total and its per-month equivalent', () => {
     for (const tier of [pro, scale]) {
       expect(formatPriceCaption(tier)).toContain(
-        formatPlanPrice(tier.monthlyPrice)
+        formatPlanPrice(tier.yearlyPrice!)
       )
       expect(formatPriceCaption(tier)).toContain(
-        formatPlanPrice(tier.yearlyPrice!)
+        formatPlanPrice(monthlyEquivalent(tier)!)
       )
     }
   })
@@ -136,5 +139,36 @@ describe('findPlanTier', () => {
     expect(findPlanTier(undefined)).toBeUndefined()
     expect(findPlanTier(null)).toBeUndefined()
     expect(findPlanTier('')).toBeUndefined()
+  })
+})
+
+// A CTA that omits the interval stops on the chooser instead of continuing to
+// the payment page, so the interval is pinned here rather than trusted to each
+// call site.
+describe('checkoutPath', () => {
+  it('always names an interval', () => {
+    for (const tier of PLAN_TIERS) {
+      expect(checkoutPath(tier.id)).toContain('billingInterval=')
+    }
+  })
+
+  it('defaults to the month-to-month interval', () => {
+    expect(checkoutPath('pro')).toBe('/checkout/pro?billingInterval=monthly')
+    expect(checkoutPath('scale')).toBe('/checkout/scale?billingInterval=monthly')
+  })
+
+  it('carries an explicit interval through', () => {
+    expect(checkoutPath('pro', 'yearly')).toBe(
+      '/checkout/pro?billingInterval=yearly'
+    )
+  })
+})
+
+// Mirrors the published refund policy. Quoting a longer window than we honour
+// would be a promise we do not keep.
+describe('MONEY_BACK_DAYS', () => {
+  it('matches the refund policy for each interval', () => {
+    expect(MONEY_BACK_DAYS.monthly).toBe(7)
+    expect(MONEY_BACK_DAYS.yearly).toBe(14)
   })
 })

--- a/web/lib/plans.ts
+++ b/web/lib/plans.ts
@@ -13,6 +13,8 @@
  * price in front of a customer.
  */
 
+export type BillingInterval = 'monthly' | 'yearly'
+
 export type PlanTier = {
   /** Matches the checkout route segment: /checkout/{id}. */
   id: string
@@ -93,6 +95,34 @@ export function findPlanTier(name: string | undefined | null) {
   return PLAN_TIERS.find((tier) => tier.id === key)
 }
 
+/** The interval an in-app CTA commits to unless the caller says otherwise. */
+export const DEFAULT_CHECKOUT_INTERVAL: BillingInterval = 'monthly'
+
+/**
+ * Checkout URL for an upgrade CTA.
+ *
+ * Naming the interval is not cosmetic: /checkout/{plan} continues straight to
+ * the payment page when the URL carries one, and stops on an interval chooser
+ * when it does not. Going through this helper keeps a call site from omitting
+ * it by accident.
+ */
+export function checkoutPath(
+  planId: string,
+  interval: BillingInterval = DEFAULT_CHECKOUT_INTERVAL,
+): string {
+  return `/checkout/${planId}?billingInterval=${interval}`
+}
+
+/**
+ * Refund window by interval, mirroring the published refund policy
+ * (textbee-marketing refund-policy/page.tsx). Quoting the wrong number here
+ * would be a promise we do not keep.
+ */
+export const MONEY_BACK_DAYS: Record<BillingInterval, number> = {
+  monthly: 7,
+  yearly: 14,
+}
+
 /**
  * What a yearly plan works out to per month, so the saving is legible without
  * making the reader divide. Derived rather than stored: a hardcoded figure
@@ -111,17 +141,21 @@ export function yearlySavingPercent(tier: PlanTier): number | undefined {
 }
 
 /**
- * The caption under a headline per-month figure, e.g. "billed yearly at
- * $99.99, or $9.99 monthly". Assumes the per-month figure is already shown
- * above it, so it does not repeat it.
+ * The caption under a headline month-to-month price, e.g. "or $8.33/month
+ * billed yearly at $99.99".
+ *
+ * The headline used to be the yearly per-month equivalent, which meant a card
+ * reading "$8.33/month" led to a $99.99 charge. The headline now matches what
+ * the CTA actually charges, and the yearly option is the discount offered
+ * underneath it rather than the number sold on.
  */
 export function formatPriceCaption(tier: PlanTier): string {
   const perMonth = monthlyEquivalent(tier)
   if (perMonth !== undefined && tier.yearlyPrice !== undefined) {
-    return `billed yearly at ${formatPlanPrice(tier.yearlyPrice)}, or ${formatPlanPrice(
-      tier.monthlyPrice,
-    )} monthly`
+    return `or ${formatPlanPrice(perMonth)}/month billed yearly at ${formatPlanPrice(
+      tier.yearlyPrice,
+    )}`
   }
   if (tier.monthlyPrice <= 0) return 'no card required'
-  return `${formatPlanPrice(tier.monthlyPrice)} billed monthly`
+  return 'billed monthly'
 }


### PR DESCRIPTION
In-app upgrade links omitted the billing interval, so they landed on the interval chooser instead of continuing to the payment page. Every one of them now passes an interval explicitly, through a single `checkoutPath()` helper so a call site cannot drop it again. The only literal `/checkout/` string left in the app is inside that helper.

Marketing links already carried the interval and are unaffected. The chooser still exists, and still preselects yearly, for a bare `/checkout/{plan}` URL.

Also in this change:

- Plan cards headline the month-to-month price the CTA actually charges. They previously led with the yearly per-month equivalent, so a card reading `$8.33/month` sent you to a `$99.99` charge.
- Plan cards and the checkout chooser quote the refund window, driven by `MONEY_BACK_DAYS` so it follows the selected interval (7 days monthly, 14 days annual) rather than quoting one number.
- The device-limit banner linked to `/pricing` and the two "Learn More" buttons linked to `/#pricing`. Neither route exists in this app, so both now point at the public pricing page.

## Testing

- `pnpm typecheck` clean
- `pnpm test`: 200 unit tests pass
- `pnpm test:e2e`: 93 pass
- New e2e case clicks the real Upgrade link on the billing page and asserts it reaches the payment page without rendering a chooser
- New unit tests pin that `checkoutPath()` always names an interval, and that `MONEY_BACK_DAYS` matches the published refund policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkout now supports monthly and yearly billing intervals with clear interval-specific pricing.
  * Checkout links consistently include the selected billing interval.
  * Refund guarantees are displayed during checkout: 7 days for monthly billing and 14 days for yearly billing.
  * Pricing and upgrade links now direct customers to the appropriate checkout or pricing page.

* **Bug Fixes**
  * Corrected pricing captions and billing details across plan selection and upgrade experiences.

* **Tests**
  * Added coverage for checkout navigation, pricing, billing intervals, and refund messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->