### PR TITLE
Record checkout status from the Polar webhook

### DIFF
--- a/api/src/billing/billing.controller.spec.ts
+++ b/api/src/billing/billing.controller.spec.ts
@@ -13,6 +13,7 @@ describe('BillingController - handlePolarWebhook', () => {
     switchPlan: jest.fn(),
     cancelSubscription: jest.fn(),
     revokeSubscription: jest.fn(),
+    syncCheckoutSessionStatus: jest.fn(),
   }
   const mockBillingNotifications = {
     listForUser: jest.fn(),
@@ -73,6 +74,7 @@ describe('BillingController - handlePolarWebhook', () => {
     mockBillingService.switchPlan.mockResolvedValue({ success: true })
     mockBillingService.cancelSubscription.mockResolvedValue({ success: true })
     mockBillingService.revokeSubscription.mockResolvedValue({ success: true })
+    mockBillingService.syncCheckoutSessionStatus.mockResolvedValue(undefined)
   })
 
   it('validates and stores every incoming payload', async () => {
@@ -143,6 +145,36 @@ describe('BillingController - handlePolarWebhook', () => {
       polarProductId: 'prod_pro_monthly',
     })
     expect(mockBillingService.cancelSubscription).not.toHaveBeenCalled()
+  })
+
+  // Polar was already sending checkout.updated, but it fell through to the
+  // default case, so isCompleted was never written for anyone.
+  it('routes checkout.updated to syncCheckoutSessionStatus', async () => {
+    await handle(
+      makePayload('checkout.updated', {
+        id: 'checkout_abc',
+        status: 'succeeded',
+      }),
+    )
+
+    expect(mockBillingService.syncCheckoutSessionStatus).toHaveBeenCalledWith({
+      checkoutSessionId: 'checkout_abc',
+      status: 'succeeded',
+    })
+    // A checkout event must never touch the subscription itself.
+    expect(mockBillingService.switchPlan).not.toHaveBeenCalled()
+    expect(mockBillingService.revokeSubscription).not.toHaveBeenCalled()
+  })
+
+  it('forwards a non-terminal checkout status and lets the service decide', async () => {
+    await handle(
+      makePayload('checkout.updated', { id: 'checkout_abc', status: 'open' }),
+    )
+
+    expect(mockBillingService.syncCheckoutSessionStatus).toHaveBeenCalledWith({
+      checkoutSessionId: 'checkout_abc',
+      status: 'open',
+    })
   })
 
   it('does not mutate any subscription for an unhandled event type', async () => {

--- a/api/src/billing/billing.controller.ts
+++ b/api/src/billing/billing.controller.ts
@@ -134,6 +134,16 @@ export class BillingController {
           polarProductId: payload.data?.product?.id,
         })
         break
+
+      case 'checkout.updated':
+        // Polar already sends these; they were being dropped here, which is
+        // why isCompleted was never written.
+        await this.billingService.syncCheckoutSessionStatus({
+          checkoutSessionId: payload.data?.id,
+          status: payload.data?.status,
+        })
+        break
+
       default:
         console.log('Unhandled polar event type:', payload.type)
         break

--- a/api/src/billing/billing.service.spec.ts
+++ b/api/src/billing/billing.service.spec.ts
@@ -214,3 +214,112 @@ describe('BillingService - checkout guards', () => {
     ).rejects.toThrow('Plan cannot be purchased')
   })
 })
+
+describe('BillingService - syncCheckoutSessionStatus', () => {
+  let service: BillingService
+
+  const mockCheckoutSessionModel = {
+    updateOne: jest.fn(),
+  }
+  const emptyModel = {}
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BillingService,
+        { provide: getModelToken(Plan.name), useValue: emptyModel },
+        { provide: getModelToken(Subscription.name), useValue: emptyModel },
+        { provide: getModelToken(User.name), useValue: emptyModel },
+        { provide: getModelToken(SMS.name), useValue: emptyModel },
+        {
+          provide: getModelToken(PolarWebhookPayload.name),
+          useValue: emptyModel,
+        },
+        {
+          provide: getModelToken(CheckoutSession.name),
+          useValue: mockCheckoutSessionModel,
+        },
+        { provide: BillingNotificationsService, useValue: {} },
+      ],
+    }).compile()
+
+    service = module.get<BillingService>(BillingService)
+
+    jest.clearAllMocks()
+    mockCheckoutSessionModel.updateOne.mockResolvedValue({ modifiedCount: 1 })
+  })
+
+  // Nothing wrote isCompleted before this existed, so a checkout the customer
+  // had already paid for stayed reusable until it expired.
+  it('marks a succeeded checkout completed', async () => {
+    await service.syncCheckoutSessionStatus({
+      checkoutSessionId: 'checkout_abc',
+      status: 'succeeded',
+    })
+
+    expect(mockCheckoutSessionModel.updateOne).toHaveBeenCalledWith(
+      { checkoutSessionId: 'checkout_abc' },
+      expect.objectContaining({ isCompleted: true, completedAt: expect.any(Date) }),
+    )
+  })
+
+  it('marks an expired checkout abandoned', async () => {
+    await service.syncCheckoutSessionStatus({
+      checkoutSessionId: 'checkout_abc',
+      status: 'expired',
+    })
+
+    expect(mockCheckoutSessionModel.updateOne).toHaveBeenCalledWith(
+      { checkoutSessionId: 'checkout_abc' },
+      { isAbandoned: true },
+    )
+  })
+
+  // open and confirmed are still in flight and failed is retryable, so the
+  // cached checkout URL has to stay usable.
+  it.each(['open', 'confirmed', 'failed'])(
+    'leaves a %s checkout untouched',
+    async (status) => {
+      await service.syncCheckoutSessionStatus({
+        checkoutSessionId: 'checkout_abc',
+        status,
+      })
+
+      expect(mockCheckoutSessionModel.updateOne).not.toHaveBeenCalled()
+    },
+  )
+
+  // The cache holds one row per user, so a late webhook for a checkout that has
+  // since been replaced must match nothing rather than clobber the new row.
+  it('keys on the checkout id, never on the user', async () => {
+    await service.syncCheckoutSessionStatus({
+      checkoutSessionId: 'checkout_stale',
+      status: 'succeeded',
+    })
+
+    const [filter] = mockCheckoutSessionModel.updateOne.mock.calls[0]
+    expect(filter).toEqual({ checkoutSessionId: 'checkout_stale' })
+    expect(filter).not.toHaveProperty('user')
+  })
+
+  it('ignores an event with no checkout id', async () => {
+    await service.syncCheckoutSessionStatus({
+      checkoutSessionId: undefined as any,
+      status: 'succeeded',
+    })
+
+    expect(mockCheckoutSessionModel.updateOne).not.toHaveBeenCalled()
+  })
+
+  // A webhook handler that throws would make Polar retry the whole event.
+  it('does not throw when the write fails', async () => {
+    mockCheckoutSessionModel.updateOne.mockRejectedValue(new Error('db down'))
+
+    await expect(
+      service.syncCheckoutSessionStatus({
+        checkoutSessionId: 'checkout_abc',
+        status: 'succeeded',
+      }),
+    ).resolves.not.toThrow()
+  })
+})

--- a/api/src/billing/billing.service.ts
+++ b/api/src/billing/billing.service.ts
@@ -1209,4 +1209,39 @@ export class BillingService {
       productName,
     })
   }
+
+  /**
+   * Mirror a Polar checkout's terminal status onto our cached checkout session.
+   *
+   * Without this nothing ever writes isCompleted, so a checkout the customer
+   * already paid for stayed reusable until it expired, and the completed count
+   * read as zero. Keyed on checkoutSessionId rather than user because the cache
+   * holds one row per user: once a newer checkout replaces it, a late webhook
+   * for the old id should match nothing rather than clobber the new row.
+   */
+  async syncCheckoutSessionStatus({
+    checkoutSessionId,
+    status,
+  }: {
+    checkoutSessionId: string
+    status: string
+  }) {
+    if (!checkoutSessionId) return
+
+    // open and confirmed are still in flight, and failed is retryable, so the
+    // cached session stays valid for all three.
+    let update: Record<string, any> | null = null
+    if (status === 'succeeded') {
+      update = { isCompleted: true, completedAt: new Date() }
+    } else if (status === 'expired') {
+      update = { isAbandoned: true }
+    }
+    if (!update) return
+
+    await this.checkoutSessionModel
+      .updateOne({ checkoutSessionId }, update)
+      .catch((error) => {
+        console.error('failed to sync checkout session status', error)
+      })
+  }
 }


### PR DESCRIPTION
Polar already sends `checkout.updated`, but the webhook switch had no case for it, so every one was stored in `polarwebhookpayloads` and then dropped by the `default` branch.

The consequence was that nothing ever wrote `isCompleted`. Two effects:

- The cached checkout session is reused while it is non-expired, not completed and not abandoned ([billing.service.ts:287-292](https://github.com/vernu/textbee/blob/dev/api/src/billing/billing.service.ts#L287-L292)). Since `isCompleted` was never set, a checkout the customer had already paid for stayed reusable until it expired.
- Any count of completed checkouts read as zero.

## Approach

`syncCheckoutSessionStatus` is keyed on `checkoutSessionId`, not on the user. The session cache holds one row per user (upsert on `{ user }`), so a late webhook for a checkout that has since been replaced must match nothing rather than overwrite the newer row.

Only terminal states are written:

| status | action |
|---|---|
| `succeeded` | `isCompleted: true`, `completedAt` |
| `expired` | `isAbandoned: true` |
| `open`, `confirmed`, `failed` | untouched, still in flight or retryable |

The handler swallows write errors rather than throwing, so a transient DB failure does not make Polar retry the whole event.

No Polar dashboard configuration is needed; these events are already being delivered.

## Testing

- `npx tsc --noEmit` clean
- Full api suite: 177 tests pass
- 8 new tests covering each status, the id-not-user keying, a missing checkout id, and the write-failure path

🤖 Generated with [Claude Code](https://claude.com/claude-code)