### PR TITLE
Stop cancelled subscriptions being restored by a later webhook

### DIFF
--- a/api/src/billing/billing.controller.spec.ts
+++ b/api/src/billing/billing.controller.spec.ts
@@ -14,6 +14,10 @@ describe('BillingController - handlePolarWebhook', () => {
     cancelSubscription: jest.fn(),
     revokeSubscription: jest.fn(),
     syncCheckoutSessionStatus: jest.fn(),
+    // Real implementation, not a stub: the controller's skip guard and the
+    // metadata/externalId fallback order are both under test here.
+    resolvePolarUserId: (data: any) =>
+      data?.metadata?.userId || data?.customer?.externalId || undefined,
   }
   const mockBillingNotifications = {
     listForUser: jest.fn(),
@@ -175,6 +179,32 @@ describe('BillingController - handlePolarWebhook', () => {
       checkoutSessionId: 'checkout_abc',
       status: 'open',
     })
+  })
+
+  // new Types.ObjectId(undefined) mints a fresh random id rather than throwing,
+  // so an unresolvable event would write a subscription against a user that
+  // does not exist.
+  it('skips a subscription event that names no user', async () => {
+    await handle(makePayload('subscription.updated', { metadata: {}, customer: {} }))
+
+    expect(mockBillingService.switchPlan).not.toHaveBeenCalled()
+    expect(mockBillingService.cancelSubscription).not.toHaveBeenCalled()
+    expect(mockBillingService.revokeSubscription).not.toHaveBeenCalled()
+    // The payload is still audited even though it was not acted on.
+    expect(mockBillingService.storePolarWebhookPayload).toHaveBeenCalledTimes(1)
+  })
+
+  it('still handles checkout events, which carry no user', async () => {
+    await handle(
+      makePayload('checkout.updated', {
+        metadata: {},
+        customer: {},
+        id: 'checkout_abc',
+        status: 'succeeded',
+      }),
+    )
+
+    expect(mockBillingService.syncCheckoutSessionStatus).toHaveBeenCalled()
   })
 
   it('does not mutate any subscription for an unhandled event type', async () => {

--- a/api/src/billing/billing.controller.ts
+++ b/api/src/billing/billing.controller.ts
@@ -79,6 +79,20 @@ export class BillingController {
     // store the payload in the database
     await this.billingService.storePolarWebhookPayload(payload)
 
+    // Every subscription event has to name one of our users. Passing an
+    // unresolved id through would reach `new Types.ObjectId(undefined)`, which
+    // mints a fresh random id rather than throwing, writing a subscription row
+    // against a user that does not exist.
+    if (payload.type?.startsWith('subscription.')) {
+      if (!this.billingService.resolvePolarUserId(payload.data)) {
+        console.error(
+          `polar webhook ${payload.type} carries no resolvable user, skipping`,
+          { subscriptionId: payload.data?.id },
+        )
+        return
+      }
+    }
+
     // Handle Polar.sh webhook events
     switch (payload.type) {
       case 'subscription.created':
@@ -87,8 +101,7 @@ export class BillingController {
         console.log('polar webhook event', payload.type)
         console.log(payload)
         await this.billingService.switchPlan({
-          userId: (payload.data?.metadata?.userId ||
-            payload.data?.customer?.externalId) as string,
+          userId: this.billingService.resolvePolarUserId(payload.data),
           newPlanPolarProductId: payload.data?.product?.id,
           currentPeriodStart: payload.data?.currentPeriodStart,
           currentPeriodEnd: payload.data?.currentPeriodEnd,
@@ -114,8 +127,7 @@ export class BillingController {
         // Record the intent without downgrading; the actual downgrade happens
         // on "subscription.revoked".
         await this.billingService.cancelSubscription({
-          userId: (payload.data?.metadata?.userId ||
-            payload.data?.customer?.externalId) as string,
+          userId: this.billingService.resolvePolarUserId(payload.data),
           polarProductId: payload.data?.product?.id,
           cancelAtPeriodEnd: payload.data?.cancelAtPeriodEnd,
           currentPeriodEnd: payload.data?.currentPeriodEnd,
@@ -129,8 +141,7 @@ export class BillingController {
         console.log(payload)
         // Access should actually end now — perform the real downgrade.
         await this.billingService.revokeSubscription({
-          userId: (payload.data?.metadata?.userId ||
-            payload.data?.customer?.externalId) as string,
+          userId: this.billingService.resolvePolarUserId(payload.data),
           polarProductId: payload.data?.product?.id,
         })
         break

--- a/api/src/billing/billing.service.spec.ts
+++ b/api/src/billing/billing.service.spec.ts
@@ -323,3 +323,135 @@ describe('BillingService - syncCheckoutSessionStatus', () => {
     ).resolves.not.toThrow()
   })
 })
+
+describe('BillingService - resolvePolarUserId', () => {
+  let service: BillingService
+  const emptyModel = {}
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BillingService,
+        { provide: getModelToken(Plan.name), useValue: emptyModel },
+        { provide: getModelToken(Subscription.name), useValue: emptyModel },
+        { provide: getModelToken(User.name), useValue: emptyModel },
+        { provide: getModelToken(SMS.name), useValue: emptyModel },
+        { provide: getModelToken(PolarWebhookPayload.name), useValue: emptyModel },
+        { provide: getModelToken(CheckoutSession.name), useValue: emptyModel },
+        { provide: BillingNotificationsService, useValue: {} },
+      ],
+    }).compile()
+    service = module.get<BillingService>(BillingService)
+  })
+
+  // Subscriptions created before externalCustomerId existed only carry
+  // metadata, and their customers can never be given an external id.
+  it('resolves a pre-externalId subscription from metadata alone', () => {
+    expect(
+      service.resolvePolarUserId({ metadata: { userId: 'u1' }, customer: {} }),
+    ).toBe('u1')
+  })
+
+  it('resolves from customer.externalId when metadata is absent', () => {
+    expect(
+      service.resolvePolarUserId({ metadata: {}, customer: { externalId: 'u2' } }),
+    ).toBe('u2')
+  })
+
+  it('prefers metadata, the field with fuller coverage', () => {
+    expect(
+      service.resolvePolarUserId({
+        metadata: { userId: 'u3' },
+        customer: { externalId: 'u3' },
+      }),
+    ).toBe('u3')
+  })
+
+  // Must be undefined, not null or '': the caller guards on falsiness before
+  // anything reaches new Types.ObjectId().
+  it('returns undefined when neither is present', () => {
+    expect(service.resolvePolarUserId({ metadata: {}, customer: {} })).toBeUndefined()
+    expect(service.resolvePolarUserId({})).toBeUndefined()
+    expect(service.resolvePolarUserId(undefined)).toBeUndefined()
+  })
+})
+
+describe('BillingService - switchPlan activation', () => {
+  let service: BillingService
+  const userId = '507f1f77bcf86cd799439011'
+  const plan = { _id: 'plan_pro', name: 'pro' }
+  const mockPlanModel = { findOne: jest.fn() }
+  const mockSubscriptionModel = { updateOne: jest.fn(), updateMany: jest.fn() }
+
+  const run = (status?: string, extra: Record<string, any> = {}) =>
+    service.switchPlan({
+      userId,
+      newPlanPolarProductId: 'prod_pro_monthly',
+      status,
+      amount: 999,
+      polarSubscriptionId: 'sub_1',
+      ...extra,
+    })
+
+  const writtenIsActive = () =>
+    mockSubscriptionModel.updateOne.mock.calls[0][1].isActive
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BillingService,
+        { provide: getModelToken(Plan.name), useValue: mockPlanModel },
+        { provide: getModelToken(Subscription.name), useValue: mockSubscriptionModel },
+        { provide: getModelToken(User.name), useValue: {} },
+        { provide: getModelToken(SMS.name), useValue: {} },
+        { provide: getModelToken(PolarWebhookPayload.name), useValue: {} },
+        { provide: getModelToken(CheckoutSession.name), useValue: {} },
+        { provide: BillingNotificationsService, useValue: {} },
+      ],
+    }).compile()
+    service = module.get<BillingService>(BillingService)
+    jest.clearAllMocks()
+    mockPlanModel.findOne.mockResolvedValue(plan)
+    mockSubscriptionModel.updateMany.mockResolvedValue({ modifiedCount: 0 })
+    mockSubscriptionModel.updateOne.mockResolvedValue({ upsertedCount: 0 })
+  })
+
+  it.each(['active', 'trialing', 'past_due'])(
+    'keeps access on %s',
+    async (status) => {
+      await run(status)
+      expect(writtenIsActive()).toBe(true)
+    },
+  )
+
+  // The regression: Polar emits a trailing "canceled" subscription.updated
+  // after subscription.revoked. This used to write isActive: true and restore
+  // the subscription that had just been revoked.
+  it.each(['canceled', 'unpaid', 'incomplete_expired', 'incomplete'])(
+    'does not restore access on %s',
+    async (status) => {
+      await run(status)
+      expect(writtenIsActive()).toBe(false)
+    },
+  )
+
+  // A payload that simply omits status must not be read as a revocation.
+  it('treats a missing status as active', async () => {
+    await run(undefined)
+    expect(writtenIsActive()).toBe(true)
+  })
+
+  it('still records the status it was given', async () => {
+    await run('canceled')
+    expect(mockSubscriptionModel.updateOne.mock.calls[0][1].status).toBe('canceled')
+  })
+
+  it('warns when activating a paid plan with no polar subscription id', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    await run('active', { polarSubscriptionId: undefined })
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('no polarSubscriptionId'),
+    )
+    warn.mockRestore()
+  })
+})

--- a/api/src/billing/billing.service.spec.ts
+++ b/api/src/billing/billing.service.spec.ts
@@ -446,6 +446,36 @@ describe('BillingService - switchPlan activation', () => {
     expect(mockSubscriptionModel.updateOne.mock.calls[0][1].status).toBe('canceled')
   })
 
+  // Subscriptions granted by hand (crypto payments, free access, custom deals)
+  // live only in our DB. Polar knows nothing about them, so a webhook for an
+  // unrelated, long-dead Polar subscription must not switch one off in passing.
+  it('leaves a manually granted plan alone when an old subscription is cancelled', async () => {
+    await run('canceled')
+
+    expect(mockSubscriptionModel.updateMany).not.toHaveBeenCalled()
+  })
+
+  it('does not create a row for a plan the user never held', async () => {
+    await run('canceled')
+
+    expect(mockSubscriptionModel.updateOne.mock.calls[0][2]).toEqual({
+      upsert: false,
+    })
+  })
+
+  // The normal upgrade path must still move the user off their previous plan.
+  it('still migrates off other plans when the event grants access', async () => {
+    await run('active')
+
+    expect(mockSubscriptionModel.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ isActive: true }),
+      expect.objectContaining({ isActive: false }),
+    )
+    expect(mockSubscriptionModel.updateOne.mock.calls[0][2]).toEqual({
+      upsert: true,
+    })
+  })
+
   it('warns when activating a paid plan with no polar subscription id', async () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
     await run('active', { polarSubscriptionId: undefined })

--- a/api/src/billing/billing.service.ts
+++ b/api/src/billing/billing.service.ts
@@ -10,6 +10,7 @@ import { Plan, PlanDocument } from './schemas/plan.schema'
 import {
   Subscription,
   SubscriptionDocument,
+  isActiveSubscriptionStatus,
 } from './schemas/subscription.schema'
 import { Polar } from '@polar-sh/sdk'
 import { User, UserDocument } from '../users/schemas/user.schema'
@@ -475,32 +476,26 @@ export class BillingService {
       }
     }
 
-    // Older subscriptions predate storing polarSubscriptionId; checkouts have
-    // always set externalCustomerId to the user id, so recover it from there
+    // Older subscriptions predate storing polarSubscriptionId, so look the
+    // subscription up by the identity we sent at checkout instead.
     if (!polarSubscription || polarSubscription.status === 'canceled') {
-      try {
-        const page = await this.polarApi.subscriptions.list({
-          externalCustomerId: user._id.toString(),
-          active: true,
-          limit: 1,
-        })
-        polarSubscription = page?.result?.items?.[0] ?? null
+      polarSubscription = await this.findActivePolarSubscription(
+        user._id.toString(),
+      )
 
-        if (polarSubscription) {
-          this.subscriptionModel
-            .updateOne(
-              { _id: currentSubscription._id },
-              {
-                polarSubscriptionId: polarSubscription.id,
-                polarCustomerId: polarSubscription.customerId,
-              },
-            )
-            .catch((error) => {
-              console.error(error)
-            })
-        }
-      } catch (error) {
-        console.error('failed to list polar subscriptions', error)
+      if (polarSubscription) {
+        // Store the ids so the next plan change can skip all of this.
+        this.subscriptionModel
+          .updateOne(
+            { _id: currentSubscription._id },
+            {
+              polarSubscriptionId: polarSubscription.id,
+              polarCustomerId: polarSubscription.customerId,
+            },
+          )
+          .catch((error) => {
+            console.error(error)
+          })
       }
     }
 
@@ -770,6 +765,34 @@ export class BillingService {
     })
   }
 
+  /**
+   * Find a user's active Polar subscription without relying on a stored id.
+   *
+   * Ordered by coverage, not preference. `metadata.userId` is on effectively
+   * every subscription we have ever created; `externalCustomerId` only exists
+   * for customers created after it was introduced, and cannot be added to the
+   * older ones. Querying external id alone silently found nothing for those
+   * users, and the caller then sent them into a second checkout.
+   */
+  private async findActivePolarSubscription(userId: string) {
+    const lookups: Record<string, any>[] = [
+      { metadata: { userId }, active: true, limit: 1 },
+      { externalCustomerId: userId, active: true, limit: 1 },
+    ]
+
+    for (const query of lookups) {
+      try {
+        const page = await this.polarApi.subscriptions.list(query as any)
+        const found = page?.result?.items?.[0]
+        if (found) return found
+      } catch (error) {
+        console.error('failed to list polar subscriptions', error)
+      }
+    }
+
+    return null
+  }
+
   async switchPlan({
     userId,
     newPlanName,
@@ -832,11 +855,25 @@ export class BillingService {
     )
     console.log(`Deactivated subscriptions: ${result.modifiedCount}`)
 
+    // The status Polar sends decides whether access continues. This used to be
+    // a hardcoded `true`, so the trailing "canceled" update Polar emits after
+    // subscription.revoked came straight back through here and restored the
+    // subscription it had just revoked.
+    const isActive = isActiveSubscriptionStatus(status)
+
+    if (isActive && !polarSubscriptionId && (amount ?? 0) > 0) {
+      // Nothing links this row back to Polar, which is what left older paid
+      // subscriptions unresolvable and pushed those users into a second checkout.
+      console.warn(
+        `switchPlan: activating a paid subscription for user ${userId} with no polarSubscriptionId`,
+      )
+    }
+
     // Create or update the new subscription
     const updateResult = await this.subscriptionModel.updateOne(
       { user: userObjectId, plan: plan._id },
       {
-        isActive: true,
+        isActive,
         currentPeriodStart,
         currentPeriodEnd,
         subscriptionStartDate,
@@ -1191,8 +1228,23 @@ export class BillingService {
     }
   }
 
+  /**
+   * Resolve a Polar payload back to one of our user ids.
+   *
+   * `metadata.userId` is tried first because it is the more complete of the
+   * two: it has been set on every checkout since the integration launched,
+   * whereas `externalCustomerId` was added later and, being immutable in Polar
+   * once set, can never be backfilled onto customers created before that. The
+   * two have never disagreed, so the order only decides which gaps are covered.
+   */
+  resolvePolarUserId(data: any): string | undefined {
+    return data?.metadata?.userId || data?.customer?.externalId || undefined
+  }
+
   async storePolarWebhookPayload(payload: any) {
-    const userId = payload.data?.metadata?.userId || payload.data?.userId
+    // Same resolution the webhook routing uses, so the stored audit row cannot
+    // disagree with the subscription the event actually acted on.
+    const userId = this.resolvePolarUserId(payload.data)
     const eventType = payload.type
     const name = payload.data?.customer?.name || payload.data?.customerName
     const email = payload.data?.customer?.email || payload.data?.customerEmail

--- a/api/src/billing/billing.service.ts
+++ b/api/src/billing/billing.service.ts
@@ -848,18 +848,23 @@ export class BillingService {
 
     console.log(`Found plan: ${plan.name}`)
 
-    // Deactivate current active subscriptions
-    const result = await this.subscriptionModel.updateMany(
-      { user: userObjectId, plan: { $ne: plan._id }, isActive: true },
-      { isActive: false, subscriptionEndDate: new Date() },
-    )
-    console.log(`Deactivated subscriptions: ${result.modifiedCount}`)
-
     // The status Polar sends decides whether access continues. This used to be
     // a hardcoded `true`, so the trailing "canceled" update Polar emits after
     // subscription.revoked came straight back through here and restored the
     // subscription it had just revoked.
     const isActive = isActiveSubscriptionStatus(status)
+
+    // Only an event that grants access may move a user off their other plans.
+    // Plans granted by hand (crypto payments, free access, custom deals) have no
+    // Polar record at all, so a late webhook for a long-dead Polar subscription
+    // must not be allowed to switch one off on its way past.
+    if (isActive) {
+      const result = await this.subscriptionModel.updateMany(
+        { user: userObjectId, plan: { $ne: plan._id }, isActive: true },
+        { isActive: false, subscriptionEndDate: new Date() },
+      )
+      console.log(`Deactivated subscriptions: ${result.modifiedCount}`)
+    }
 
     if (isActive && !polarSubscriptionId && (amount ?? 0) > 0) {
       // Nothing links this row back to Polar, which is what left older paid
@@ -886,7 +891,10 @@ export class BillingService {
         polarCustomerId,
         cancelAtPeriodEnd,
       },
-      { upsert: true },
+      // Only create a row for a subscription that is actually live. A terminal
+      // event for a plan we hold no row for has nothing to record, and minting
+      // an inactive row for it would invent history the user never had.
+      { upsert: isActive },
     )
     console.log(
       `Updated or created subscription: ${updateResult.upsertedCount > 0 ? 'Created' : 'Updated'}`,

--- a/api/src/billing/schemas/subscription.schema.ts
+++ b/api/src/billing/schemas/subscription.schema.ts
@@ -13,6 +13,24 @@ export enum SubscriptionStatus {
   Unpaid = 'unpaid',
 }
 
+/** The statuses under which a subscriber still has paid access. */
+export const ACTIVE_SUBSCRIPTION_STATUSES: string[] = [
+  SubscriptionStatus.Trialing,
+  SubscriptionStatus.Active,
+  SubscriptionStatus.PastDue,
+]
+
+/**
+ * Whether a Polar status should grant access.
+ *
+ * An absent status counts as active: a payload that simply omits it must never
+ * be read as a revocation, since that would silently cut off a paying customer.
+ */
+export function isActiveSubscriptionStatus(status?: string): boolean {
+  if (status === undefined || status === null) return true
+  return ACTIVE_SUBSCRIPTION_STATUSES.includes(status)
+}
+
 export type SubscriptionDocument = Subscription & Document
 
 @Schema({ timestamps: true })
@@ -76,5 +94,11 @@ export class Subscription {
 
 export const SubscriptionSchema = SchemaFactory.createForClass(Subscription)
 
-// a user can only have one active subscription at a time
-SubscriptionSchema.index({ user: 1, isActive: 1 }, { unique: true })
+// A user can only have one ACTIVE subscription at a time. Partial on purpose:
+// the previous unique { user, isActive } also forbade a second *inactive* row,
+// so it could never build against real history and was absent in production,
+// leaving this rule unenforced.
+SubscriptionSchema.index(
+  { user: 1 },
+  { unique: true, partialFilterExpression: { isActive: true } },
+)


### PR DESCRIPTION
Fixes several defects in how Polar webhook events are applied to subscription records.

## Cancelled subscriptions could be restored

`switchPlan` wrote `isActive: true` unconditionally, ignoring the `status` on the payload. Polar emits trailing `subscription.updated` / `subscription.canceled` events carrying `status=canceled` after `subscription.revoked`, and the controller routes those back through `switchPlan`, which reactivated the subscription that was just revoked.

`isActive` now follows the status. An absent status still counts as active, so a partial payload can never be read as a revocation.

## A terminal event could affect an unrelated subscription

`switchPlan` deactivated every other active subscription for the user before looking at the status, so a late event for a long-dead subscription could switch off an unrelated one on its way past. The migration is now gated on the event actually granting access, and the upsert follows the same rule so a terminal event cannot create a row that never existed.

## Identity resolution

One helper for all call sites, ordered `metadata.userId` then `customer.externalId`.

`metadata.userId` has been set on every checkout since the integration launched. `externalCustomerId` was added later and is immutable in Polar once set, so it cannot be backfilled onto customers created before it. Resolving by external id alone therefore misses the earlier records entirely. The two have never disagreed where both are present, so the order only decides which gaps are covered.

Two consequences fixed:

- The plan-change recovery lookup queried `externalCustomerId` only, under a comment claiming checkouts "have always set" it. For earlier records it silently found nothing and fell through to creating a **new checkout** alongside the subscription the user already had. It now queries by metadata first.
- `storePolarWebhookPayload` used `metadata.userId || data.userId`, where `data.userId` is not a field Polar sends. It resolved differently from the routing, so the stored audit row could disagree with the subscription the event acted on.

## Unresolvable events

Subscription events that resolve to no user are now skipped. `new Types.ObjectId(undefined)` mints a fresh random id rather than throwing, so an unresolved id would write a subscription row against a user that does not exist.

## Index

Replaces the unique `{ user, isActive }` index with a partial unique index on `{ user }` where `isActive: true`.

The old form also forbade a second *inactive* row per user, so it could not build against real subscription history and was absent in practice, leaving "one active subscription per user" unenforced.

## Testing

- `npx tsc --noEmit` clean
- Full api suite: 196 tests pass
- New coverage: every status through `switchPlan` including terminal ones and a missing status, the migration gate in both directions, the resolver across metadata-only / external-only / both / neither, and the skip guard
- The migration-gate tests were verified against a reverted fix to confirm they fail without it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing webhook processing when customer identity information is incomplete.
  * Preserved checkout synchronization even when a user cannot be identified.
  * Subscription access now reflects provider status, including active, revoked, and incomplete subscriptions.
  * Improved recovery of subscription links for existing customers.
  * Prevented duplicate active subscriptions for the same account.
  * Improved plan switching while preserving manually granted access.
  * Prevented inactive subscription events from incorrectly changing account access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->