### PR TITLE
Add get device by id endpoint to the gateway API

### DIFF
--- a/api/src/gateway/gateway.controller.ts
+++ b/api/src/gateway/gateway.controller.ts
@@ -79,6 +79,18 @@ export class GatewayController {
     return { data }
   }
 
+  @ApiOperation({ summary: 'Get device by id' })
+  @UseGuards(AuthGuard, CanModifyDevice)
+  @Get('/devices/:id')
+  async getDevice(@Param('id') deviceId: string) {
+    const data = await this.gatewayService.getDeviceById(
+      deviceId,
+      undefined,
+      '-fcmToken -serial',
+    )
+    return { data }
+  }
+
   @ApiOperation({ summary: 'Update device' })
   @UseGuards(AuthGuard, CanModifyDevice)
   @Patch('/devices/:id')

--- a/api/src/gateway/gateway.service.spec.ts
+++ b/api/src/gateway/gateway.service.spec.ts
@@ -352,8 +352,18 @@ describe('GatewayService', () => {
 
       const result = await service.getDeviceById('device123')
 
-      expect(mockDeviceModel.findById).toHaveBeenCalledWith('device123')
+      expect(mockDeviceModel.findById).toHaveBeenCalledWith('device123', undefined)
       expect(result).toEqual(mockDevice)
+    })
+
+    it('should apply the given projection', async () => {
+      mockDeviceModel.findById.mockResolvedValue(mockDevice)
+
+      await service.getDeviceById('device123', undefined, '-fcmToken -serial')
+
+      const [, projection] = mockDeviceModel.findById.mock.calls[0]
+      expect(projection).toContain('-fcmToken')
+      expect(projection).toContain('-serial')
     })
   })
 

--- a/api/src/gateway/gateway.service.ts
+++ b/api/src/gateway/gateway.service.ts
@@ -157,16 +157,23 @@ export class GatewayService {
     )
   }
 
-  async getDeviceById(deviceId: string, userId?: string): Promise<any> {
+  async getDeviceById(
+    deviceId: string,
+    userId?: string,
+    projection?: string,
+  ): Promise<any> {
     if (userId) {
       // Explicit casts so the scoped lookup never depends on schema-level
       // string casting.
-      return await this.deviceModel.findOne({
-        _id: new Types.ObjectId(deviceId),
-        user: new Types.ObjectId(userId),
-      })
+      return await this.deviceModel.findOne(
+        {
+          _id: new Types.ObjectId(deviceId),
+          user: new Types.ObjectId(userId),
+        },
+        projection,
+      )
     }
-    return await this.deviceModel.findById(deviceId)
+    return await this.deviceModel.findById(deviceId, projection)
   }
 
   // Picks the device a deviceless send should go out from. An explicit id is


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/gateway/devices/:id` to fetch a single device, guarded by `AuthGuard` + `CanModifyDevice` like the other device-scoped routes (404 for a missing or foreign device, 400 for an invalid id).
- `GatewayService.getDeviceById` gains an optional projection parameter; the endpoint passes `-fcmToken -serial` so the push credential and hardware serial are excluded from the response, matching the device list endpoint.
- Adds a spec asserting the projection is applied.

## Test plan

- [x] `pnpm test` in `api/`: 218/218 passing
- [x] `pnpm build` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for retrieving device details by ID.
  * Device responses omit sensitive FCM token and serial information.
  * Access is restricted to users authorized to modify the device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->