### PR TITLE
Send no-cache for the swagger init script

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -51,9 +51,17 @@ async function bootstrap() {
     )
     .build()
   const document = SwaggerModule.createDocument(app, config)
-  // Browsers heuristically cache the spec otherwise and keep serving old docs
+  // Every route that carries the spec itself, including swagger-ui-init.js,
+  // which embeds the whole document and is otherwise cached as a static .js
+  // by CDNs and browsers. The swagger-ui library assets stay cacheable.
+  const SPEC_ROUTES = new Set([
+    '/',
+    '/-json',
+    '/-yaml',
+    '/swagger-ui-init.js',
+  ])
   app.use((req, res, next) => {
-    if (req.path === '/' || req.path === '/-json' || req.path === '/-yaml') {
+    if (SPEC_ROUTES.has(req.path)) {
       res.setHeader('Cache-Control', 'no-cache')
     }
     next()


### PR DESCRIPTION
`swagger-ui-init.js` embeds the full OpenAPI document, but it was the one spec-carrying route not covered by the docs cache headers, so it was treated as a static asset: the origin sent no `Cache-Control`, Cloudflare applied its default 4h browser TTL and edge-cached it (`cf-cache-status: HIT`). The docs page therefore rendered a stale spec after a deploy even though `/-json` was already correct.

Adds it to the same no-cache list as `/`, `/-json` and `/-yaml`. The swagger-ui library assets are untouched and stay cacheable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Swagger documentation caching behavior to ensure initialization resources are always refreshed.
  * Preserved existing cache-control handling for Swagger specification routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->