### PR TITLE
Fix the Android version reported in device info

### DIFF
--- a/android/app/src/main/java/com/vernu/sms/activities/MainActivity.java
+++ b/android/app/src/main/java/com/vernu/sms/activities/MainActivity.java
@@ -501,7 +501,10 @@ public class MainActivity extends AppCompatActivity {
                     registerDeviceInput.setManufacturer(Build.MANUFACTURER);
                     registerDeviceInput.setModel(Build.MODEL);
                     registerDeviceInput.setBuildId(Build.ID);
-                    registerDeviceInput.setOs(Build.VERSION.BASE_OS);
+                    registerDeviceInput.setOs("Android");
+                    registerDeviceInput.setOsVersion(Build.VERSION.RELEASE);
+                    registerDeviceInput.setOsApiLevel(Build.VERSION.SDK_INT);
+                    registerDeviceInput.setOsBuildFingerprint(Build.VERSION.BASE_OS);
                     registerDeviceInput.setAppVersionCode(BuildConfig.VERSION_CODE);
                     registerDeviceInput.setAppVersionName(BuildConfig.VERSION_NAME);
                     
@@ -680,7 +683,10 @@ public class MainActivity extends AppCompatActivity {
                     updateDeviceInput.setManufacturer(Build.MANUFACTURER);
                     updateDeviceInput.setModel(Build.MODEL);
                     updateDeviceInput.setBuildId(Build.ID);
-                    updateDeviceInput.setOs(Build.VERSION.BASE_OS);
+                    updateDeviceInput.setOs("Android");
+                    updateDeviceInput.setOsVersion(Build.VERSION.RELEASE);
+                    updateDeviceInput.setOsApiLevel(Build.VERSION.SDK_INT);
+                    updateDeviceInput.setOsBuildFingerprint(Build.VERSION.BASE_OS);
                     updateDeviceInput.setAppVersionCode(BuildConfig.VERSION_CODE);
                     updateDeviceInput.setAppVersionName(BuildConfig.VERSION_NAME);
 

--- a/android/app/src/main/java/com/vernu/sms/dtos/HeartbeatInputDTO.kt
+++ b/android/app/src/main/java/com/vernu/sms/dtos/HeartbeatInputDTO.kt
@@ -7,6 +7,8 @@ class HeartbeatInputDTO {
     var networkType: String? = null
     var appVersionName: String? = null
     var appVersionCode: Int? = null
+    var osVersion: String? = null
+    var osApiLevel: Int? = null
     var deviceUptimeMillis: Long? = null
     var memoryFreeBytes: Long? = null
     var memoryTotalBytes: Long? = null

--- a/android/app/src/main/java/com/vernu/sms/dtos/RegisterDeviceInputDTO.kt
+++ b/android/app/src/main/java/com/vernu/sms/dtos/RegisterDeviceInputDTO.kt
@@ -11,6 +11,8 @@ class RegisterDeviceInputDTO {
     var buildId: String? = null
     var os: String? = null
     var osVersion: String? = null
+    var osApiLevel: Int? = null
+    var osBuildFingerprint: String? = null
     var appVersionName: String? = null
     var appVersionCode: Int = 0
     var simInfo: SimInfoCollectionDTO? = null

--- a/android/app/src/main/java/com/vernu/sms/helpers/HeartbeatHelper.kt
+++ b/android/app/src/main/java/com/vernu/sms/helpers/HeartbeatHelper.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.os.BatteryManager
+import android.os.Build
 import android.os.StatFs
 import android.os.SystemClock
 import android.util.Log
@@ -79,6 +80,10 @@ object HeartbeatHelper {
             // App version
             heartbeatInput.appVersionName = BuildConfig.VERSION_NAME
             heartbeatInput.appVersionCode = BuildConfig.VERSION_CODE
+
+            // OS version, so devices backfill without needing to re-register
+            heartbeatInput.osVersion = Build.VERSION.RELEASE
+            heartbeatInput.osApiLevel = Build.VERSION.SDK_INT
 
             // Device uptime
             heartbeatInput.deviceUptimeMillis = SystemClock.uptimeMillis()

--- a/android/app/src/main/java/com/vernu/sms/ui/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/onboarding/OnboardingViewModel.kt
@@ -104,7 +104,10 @@ class OnboardingViewModel : ViewModel() {
                     manufacturer = Build.MANUFACTURER
                     model = Build.MODEL
                     buildId = Build.ID
-                    os = Build.VERSION.BASE_OS
+                    os = "Android"
+                    osVersion = Build.VERSION.RELEASE
+                    osApiLevel = Build.VERSION.SDK_INT
+                    osBuildFingerprint = Build.VERSION.BASE_OS
                     appVersionCode = BuildConfig.VERSION_CODE
                     appVersionName = BuildConfig.VERSION_NAME
                     name = current.deviceName.ifEmpty { "${Build.BRAND} ${Build.MODEL}" }

--- a/api/src/gateway/gateway.dto.ts
+++ b/api/src/gateway/gateway.dto.ts
@@ -71,6 +71,12 @@ export class RegisterDeviceInputDTO {
   @ApiProperty({ type: String })
   osVersion?: string
 
+  @ApiProperty({ type: Number, required: false })
+  osApiLevel?: number
+
+  @ApiProperty({ type: String, required: false })
+  osBuildFingerprint?: string
+
   @ApiProperty({ type: String })
   appVersionName?: string
 
@@ -424,6 +430,20 @@ export class HeartbeatInputDTO {
     description: 'App version code',
   })
   appVersionCode?: number
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Android release version, e.g. "16"',
+  })
+  osVersion?: string
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Android SDK / API level, e.g. 36',
+  })
+  osApiLevel?: number
 
   @ApiProperty({
     type: Number,

--- a/api/src/gateway/gateway.service.spec.ts
+++ b/api/src/gateway/gateway.service.spec.ts
@@ -255,6 +255,69 @@ describe('GatewayService', () => {
       )
     })
 
+    describe('os version normalization', () => {
+      const FINGERPRINT =
+        'samsung/a13nnxx/a13:14/UP1A.231005.007/A135FXXUAEXL2:user/release-keys'
+
+      beforeEach(() => {
+        mockDeviceModel.findOne.mockResolvedValue(null)
+        mockBillingService.getUserLimits.mockResolvedValue({ deviceLimit: -1 })
+        mockDeviceModel.create.mockResolvedValue({ _id: 'device123' })
+      })
+
+      it('derives osVersion from a legacy client sending only BASE_OS', async () => {
+        await service.registerDevice(
+          { ...mockDeviceInput, os: FINGERPRINT } as RegisterDeviceInputDTO,
+          mockUser,
+        )
+
+        expect(mockDeviceModel.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            os: 'Android',
+            osVersion: '14',
+            osBuildFingerprint: FINGERPRINT,
+          }),
+        )
+      })
+
+      it('never persists a raw BASE_OS fingerprint in the display field', async () => {
+        await service.registerDevice(
+          { ...mockDeviceInput, os: FINGERPRINT } as RegisterDeviceInputDTO,
+          mockUser,
+        )
+
+        const created = mockDeviceModel.create.mock.calls[0][0]
+        expect(created.os).toBe('Android')
+      })
+
+      it('stores no osVersion when a legacy client reports a blank BASE_OS', async () => {
+        await service.registerDevice(
+          { ...mockDeviceInput, os: '' } as RegisterDeviceInputDTO,
+          mockUser,
+        )
+
+        const created = mockDeviceModel.create.mock.calls[0][0]
+        expect(created).not.toHaveProperty('osVersion')
+        expect(created).not.toHaveProperty('osBuildFingerprint')
+      })
+
+      it('passes through the version a current client reports', async () => {
+        await service.registerDevice(
+          {
+            ...mockDeviceInput,
+            os: 'Android',
+            osVersion: '16',
+            osApiLevel: 36,
+          } as RegisterDeviceInputDTO,
+          mockUser,
+        )
+
+        expect(mockDeviceModel.create).toHaveBeenCalledWith(
+          expect.objectContaining({ os: 'Android', osVersion: '16', osApiLevel: 36 }),
+        )
+      })
+    })
+
     it('should block registration when the device limit is already reached', async () => {
       mockDeviceModel.findOne.mockResolvedValue(null)
       mockBillingService.getUserLimits.mockResolvedValue({ deviceLimit: 1 })
@@ -609,6 +672,23 @@ describe('GatewayService', () => {
       ).rejects.toThrow(HttpException)
       expect(mockDeviceModel.findById).toHaveBeenCalledWith(mockDeviceId)
       expect(mockDeviceModel.findByIdAndUpdate).not.toHaveBeenCalled()
+    })
+
+    it('must not blank a stored osVersion when a legacy client sends an empty BASE_OS', async () => {
+      // BASE_OS is '' on many devices, and '' is not null, so it reaches
+      // $set unless normalizeOsFields drops it. If this regresses, a single
+      // re-register wipes the backfilled version for those devices.
+      mockDeviceModel.findById.mockResolvedValue({ ...mockDevice, osVersion: '14' })
+      mockDeviceModel.findByIdAndUpdate.mockResolvedValue(mockDevice)
+
+      await service.updateDevice(mockDeviceId, {
+        ...mockDeviceInput,
+        os: '',
+      } as RegisterDeviceInputDTO)
+
+      const [, update] = mockDeviceModel.findByIdAndUpdate.mock.calls[0]
+      expect(update.$set).not.toHaveProperty('osVersion')
+      expect(update.$set.os).toBe('Android')
     })
 
     it('should ignore a client-sent isDefault', async () => {

--- a/api/src/gateway/gateway.service.ts
+++ b/api/src/gateway/gateway.service.ts
@@ -108,8 +108,11 @@ export class GatewayService {
     const deviceData: any = { ...input, user }
     // set-default is the only writer; there is no ValidationPipe to strip it
     delete deviceData.isDefault
-    // normalizeOsFields owns these; raw BASE_OS must never reach the display field
+    // normalizeOsFields owns these; raw OS metadata must never reach the display fields
     delete deviceData.os
+    delete deviceData.osVersion
+    delete deviceData.osApiLevel
+    delete deviceData.osBuildFingerprint
     Object.assign(deviceData, normalizeOsFields(input))
 
     // Set default name to "brand model" if not provided
@@ -291,8 +294,11 @@ export class GatewayService {
     const updateData: any = { ...input }
     // set-default is the only writer; there is no ValidationPipe to strip it
     delete updateData.isDefault
-    // normalizeOsFields owns these; raw BASE_OS must never reach the display field
+    // normalizeOsFields owns these; raw OS metadata must never reach the display fields
     delete updateData.os
+    delete updateData.osVersion
+    delete updateData.osApiLevel
+    delete updateData.osBuildFingerprint
     Object.assign(updateData, normalizeOsFields(input))
 
     // Handle simInfo if provided

--- a/api/src/gateway/gateway.service.ts
+++ b/api/src/gateway/gateway.service.ts
@@ -25,6 +25,7 @@ import { WebhookService } from '../webhook/webhook.service'
 import { BillingService } from '../billing/billing.service'
 import { SmsQueueService } from './queue/sms-queue.service'
 import { escapeRegExp } from '../common/escape-regexp'
+import { normalizeOsFields } from './os-version'
 
 @Injectable()
 export class GatewayService {
@@ -107,6 +108,9 @@ export class GatewayService {
     const deviceData: any = { ...input, user }
     // set-default is the only writer; there is no ValidationPipe to strip it
     delete deviceData.isDefault
+    // normalizeOsFields owns these; raw BASE_OS must never reach the display field
+    delete deviceData.os
+    Object.assign(deviceData, normalizeOsFields(input))
 
     // Set default name to "brand model" if not provided
     if (!deviceData.name && input.brand && input.model) {
@@ -287,6 +291,9 @@ export class GatewayService {
     const updateData: any = { ...input }
     // set-default is the only writer; there is no ValidationPipe to strip it
     delete updateData.isDefault
+    // normalizeOsFields owns these; raw BASE_OS must never reach the display field
+    delete updateData.os
+    Object.assign(updateData, normalizeOsFields(input))
 
     // Handle simInfo if provided
     if (input.simInfo) {
@@ -1421,6 +1428,12 @@ const updatedSms = await this.smsModel.findByIdAndUpdate(
         updateData['appVersionInfo.versionCode'] = input.appVersionCode
       }
       updateData['appVersionInfo.lastUpdated'] = now
+    }
+
+    // Update OS info if provided. These change at most once per OS upgrade,
+    // so skip keys already matching the stored value to keep the write a no-op.
+    for (const [key, value] of Object.entries(normalizeOsFields(input))) {
+      if (device[key] !== value) updateData[key] = value
     }
 
     // Update deviceUptimeInfo if provided

--- a/api/src/gateway/os-version.spec.ts
+++ b/api/src/gateway/os-version.spec.ts
@@ -1,0 +1,102 @@
+import { normalizeOsFields, parseReleaseFromFingerprint } from './os-version'
+
+// Representative BASE_OS fingerprints. These are shared OEM build strings,
+// identical across every device on the same build.
+const FP_14 = 'samsung/a13nnxx/a13:14/UP1A.231005.007/A135FXXUAEXL2:user/release-keys'
+const FP_16 = 'samsung/e3qxxx/e3q:16/BP2A.250605.031.A3/S928BXXU4CYI7:user/release-keys'
+const FP_15 = 'Redmi/gale_in/gale:15/AP3A.240905.015.A2/OS2.0.206.0.VGPINXM:user/release-keys'
+const FP_7 = 'samsung/j5ylte/j5y17lte:7.0/NRD90M/J530FXXU1AQG3:user/release-keys'
+
+describe('parseReleaseFromFingerprint', () => {
+  it('pulls the release out of a fingerprint', () => {
+    expect(parseReleaseFromFingerprint(FP_14)).toBe('14')
+    expect(parseReleaseFromFingerprint(FP_16)).toBe('16')
+    expect(parseReleaseFromFingerprint(FP_15)).toBe('15')
+  })
+
+  it('keeps a dotted release verbatim', () => {
+    expect(parseReleaseFromFingerprint(FP_7)).toBe('7.0')
+  })
+
+  it('returns null when there is nothing to parse', () => {
+    expect(parseReleaseFromFingerprint('')).toBeNull()
+    expect(parseReleaseFromFingerprint(undefined)).toBeNull()
+    expect(parseReleaseFromFingerprint('Android')).toBeNull()
+    expect(parseReleaseFromFingerprint('not/a/fingerprint')).toBeNull()
+  })
+
+  it('takes the first match, not a later colon segment', () => {
+    // ':user/' trails every fingerprint and must never win.
+    expect(parseReleaseFromFingerprint(FP_14)).toBe('14')
+  })
+})
+
+describe('normalizeOsFields', () => {
+  describe('legacy clients (os = BASE_OS, no osVersion)', () => {
+    it('derives the version from the fingerprint and canonicalizes os', () => {
+      expect(normalizeOsFields({ os: FP_14 })).toEqual({
+        osVersion: '14',
+        osBuildFingerprint: FP_14,
+        os: 'Android',
+      })
+    })
+
+    it('keeps a dotted release verbatim', () => {
+      expect(normalizeOsFields({ os: FP_7 }).osVersion).toBe('7.0')
+    })
+
+    // The regression that would silently undo the backfill: BASE_OS is an
+    // empty string on many devices, and an empty string is not null, so it
+    // reaches $set unless it is dropped here.
+    it('emits no osVersion key when BASE_OS is blank', () => {
+      const patch = normalizeOsFields({ os: '' })
+      expect(patch).not.toHaveProperty('osVersion')
+      expect(patch).not.toHaveProperty('osBuildFingerprint')
+      expect(patch.os).toBe('Android')
+    })
+
+    it('emits no osVersion key when os is absent entirely', () => {
+      expect(normalizeOsFields({})).toEqual({})
+    })
+  })
+
+  describe('current clients (osVersion reported directly)', () => {
+    it('passes the reported version and api level through', () => {
+      expect(normalizeOsFields({ os: 'Android', osVersion: '16', osApiLevel: 36 })).toEqual({
+        osVersion: '16',
+        osApiLevel: 36,
+        os: 'Android',
+      })
+    })
+
+    it('prefers the reported version over the fingerprint', () => {
+      // A device that upgraded its OS but kept a stale BASE_OS string.
+      const patch = normalizeOsFields({ os: FP_14, osVersion: '16', osApiLevel: 36 })
+      expect(patch.osVersion).toBe('16')
+      expect(patch.osBuildFingerprint).toBe(FP_14)
+    })
+
+    it('stores a non-numeric release as reported', () => {
+      // Preview builds can report a codename; display handles it via osApiLevel.
+      expect(normalizeOsFields({ osVersion: 'Baklava', osApiLevel: 36 })).toEqual({
+        osVersion: 'Baklava',
+        osApiLevel: 36,
+      })
+    })
+  })
+
+  describe('partial payloads', () => {
+    it('emits nothing for a settings-toggle style body', () => {
+      expect(normalizeOsFields({} as any)).toEqual({})
+    })
+
+    it('ignores a blank reported version and falls back to the fingerprint', () => {
+      expect(normalizeOsFields({ os: FP_15, osVersion: '   ' }).osVersion).toBe('15')
+    })
+
+    it('ignores a non-numeric api level', () => {
+      const patch = normalizeOsFields({ osApiLevel: NaN as any })
+      expect(patch).not.toHaveProperty('osApiLevel')
+    })
+  })
+})

--- a/api/src/gateway/os-version.ts
+++ b/api/src/gateway/os-version.ts
@@ -17,6 +17,7 @@ export interface OsFieldsInput {
   os?: string
   osVersion?: string
   osApiLevel?: number
+  osBuildFingerprint?: string
 }
 
 export function parseReleaseFromFingerprint(raw?: string): string | null {
@@ -44,7 +45,7 @@ export function normalizeOsFields(input: OsFieldsInput): Record<string, any> {
     patch.osApiLevel = input.osApiLevel
   }
 
-  if (raw?.includes('/')) patch.osBuildFingerprint = raw
+  if (raw && raw.includes('/')) patch.osBuildFingerprint = raw
   if (input?.os !== undefined) patch.os = 'Android'
 
   return patch

--- a/api/src/gateway/os-version.ts
+++ b/api/src/gateway/os-version.ts
@@ -1,0 +1,51 @@
+/**
+ * Android OS version normalization.
+ *
+ * Older app builds only ever sent `os = Build.VERSION.BASE_OS`, a raw build
+ * fingerprint, and never sent an OS version at all. Many installs still run
+ * those builds and may never update, so the release is derived here rather
+ * than relying on the client to report it.
+ *
+ * Keep FINGERPRINT_RELEASE in sync with the copy in
+ * textbee-tools/src/textbee_tools/backfill_os_version.py
+ */
+
+/** Matches the release in a BASE_OS fingerprint: samsung/a13nnxx/a13:14/UP1A.../... */
+const FINGERPRINT_RELEASE = /:(\d+(?:\.\d+)*)\//
+
+export interface OsFieldsInput {
+  os?: string
+  osVersion?: string
+  osApiLevel?: number
+}
+
+export function parseReleaseFromFingerprint(raw?: string): string | null {
+  if (!raw) return null
+  return raw.match(FINGERPRINT_RELEASE)?.[1] ?? null
+}
+
+/**
+ * Returns only the keys we have a real value for, so a partial or legacy
+ * payload can never overwrite a stored value with '' or null.
+ */
+export function normalizeOsFields(input: OsFieldsInput): Record<string, any> {
+  const patch: Record<string, any> = {}
+  const raw = input?.os?.trim()
+
+  const reported = input?.osVersion?.trim()
+  if (reported) {
+    patch.osVersion = reported
+  } else {
+    const parsed = parseReleaseFromFingerprint(raw)
+    if (parsed) patch.osVersion = parsed
+  }
+
+  if (typeof input?.osApiLevel === 'number' && Number.isFinite(input.osApiLevel)) {
+    patch.osApiLevel = input.osApiLevel
+  }
+
+  if (raw?.includes('/')) patch.osBuildFingerprint = raw
+  if (input?.os !== undefined) patch.os = 'Android'
+
+  return patch
+}

--- a/api/src/gateway/schemas/device.schema.ts
+++ b/api/src/gateway/schemas/device.schema.ts
@@ -56,6 +56,13 @@ export class Device {
   @Prop({ type: String })
   osVersion: string
 
+  @Prop({ type: Number })
+  osApiLevel: number
+
+  // Raw Build.VERSION.BASE_OS string, kept for per-OEM detail.
+  @Prop({ type: String })
+  osBuildFingerprint: string
+
   @Prop({ type: String })
   appVersionName: string
 


### PR DESCRIPTION
## Problem

`osVersion` has existed on the device DTO and schema since the early commits, but nothing ever assigned it, so it was never populated. The only OS value actually sent was:

```java
registerDeviceInput.setOs(Build.VERSION.BASE_OS);
```

`Build.VERSION.BASE_OS` is not a version. It is a build string fragment such as `samsung/a13nnxx/a13:14/UP1A.231005.007/A135FXXUAEXL2:user/release-keys`, and many OEMs leave it empty. So device info showed either an unreadable build string or nothing at all, and the Android version itself was never recorded.

**This replaces one already-reported value with a readable one.** No new kind of information is read from the device, and no permission is involved: `Build.VERSION.RELEASE` and `Build.VERSION.SDK_INT` are public, permission-free constants that were simply never read. Both are less specific than the build string already being sent, since the build string identifies the exact OEM firmware and the release number does not.

## Changes

**Android.** Reports `Build.VERSION.RELEASE` and `Build.VERSION.SDK_INT` at the three registration/update sites and in `HeartbeatHelper`. Heartbeat matters most: registration only fires during onboarding or an explicit button press, so without it an installed device would never fill the field in. The raw build string moves to `osBuildFingerprint` rather than being discarded.

**API.** New `normalizeOsFields()` in `src/gateway/os-version.ts`, wired into `registerDevice`, `updateDevice`, and `heartbeat`.

The important part is that this runs server side. Most installs are on older builds that will never send the new fields, so relying on the client alone would leave the majority unfixed indefinitely. The normalizer derives the release from the build string an old client already sends, so those installs are corrected without updating.

It returns only the keys it has a real value for. That guard is load bearing: `BASE_OS` is an empty string on a large share of devices, and an empty string is not null, so it would otherwise reach `$set` and blank out a version that was already known.

## Tests

`os-version.spec.ts` covers the normalizer directly: build string parsing, dotted releases like `7.0`, the empty-`BASE_OS` case, and a reported version winning over a stale build string. `gateway.service.spec.ts` adds register and update cases, including an explicit assertion that an older client sending `os: ""` cannot clear a stored `osVersion`.

Full suite: 237 passed, 16 suites. Android `compileProdDebugSources` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)