### PR TITLE
Keep the build string a current client reports

### DIFF
--- a/api/src/gateway/gateway.service.spec.ts
+++ b/api/src/gateway/gateway.service.spec.ts
@@ -691,6 +691,59 @@ describe('GatewayService', () => {
       expect(update.$set.os).toBe('Android')
     })
 
+    it('persists the build string a current client reports', async () => {
+      // `os` is the plain 'Android' label now, so the build string arrives in
+      // its own field. If the normalizer ignores it the field becomes writable
+      // only by the backfill script and no app build can ever populate it.
+      const fingerprint =
+        'samsung/e3qxxx/e3q:16/BP2A.250605.031.A3/S928BXXU4CYI7:user/release-keys'
+      mockDeviceModel.findById.mockResolvedValue(mockDevice)
+      mockDeviceModel.findByIdAndUpdate.mockResolvedValue(mockDevice)
+
+      await service.updateDevice(mockDeviceId, {
+        ...mockDeviceInput,
+        os: 'Android',
+        osVersion: '16',
+        osApiLevel: 36,
+        osBuildFingerprint: fingerprint,
+      } as RegisterDeviceInputDTO)
+
+      const [, update] = mockDeviceModel.findByIdAndUpdate.mock.calls[0]
+      expect(update.$set).toMatchObject({
+        os: 'Android',
+        osVersion: '16',
+        osApiLevel: 36,
+        osBuildFingerprint: fingerprint,
+      })
+    })
+
+    it.each([
+      ['osVersion', { osVersion: '' }],
+      ['osApiLevel', { osApiLevel: null }],
+      ['osBuildFingerprint', { osBuildFingerprint: '' }],
+    ])(
+      'must not blank a stored %s sent empty by a non-first-party client',
+      async (field, payload) => {
+        // The gateway API is public and has no ValidationPipe, so these can
+        // arrive from any client, not just the Android app.
+        mockDeviceModel.findById.mockResolvedValue({
+          ...mockDevice,
+          osVersion: '14',
+          osApiLevel: 34,
+          osBuildFingerprint: 'samsung/a13nnxx/a13:14/UP1A.231005.007/x:user/release-keys',
+        })
+        mockDeviceModel.findByIdAndUpdate.mockResolvedValue(mockDevice)
+
+        await service.updateDevice(mockDeviceId, {
+          ...mockDeviceInput,
+          ...payload,
+        } as RegisterDeviceInputDTO)
+
+        const [, update] = mockDeviceModel.findByIdAndUpdate.mock.calls[0]
+        expect(update.$set).not.toHaveProperty(field)
+      },
+    )
+
     it('should ignore a client-sent isDefault', async () => {
       // set-default is the only route allowed to move the default flag
       mockDeviceModel.findById.mockResolvedValue(mockDevice)

--- a/api/src/gateway/os-version.spec.ts
+++ b/api/src/gateway/os-version.spec.ts
@@ -83,6 +83,43 @@ describe('normalizeOsFields', () => {
         osApiLevel: 36,
       })
     })
+
+    // Current clients put the build string in its own field, because `os` now
+    // carries the plain 'Android' label and so has no '/' to parse. Without
+    // this the field is only ever writable by the backfill script.
+    it('keeps the build string reported in its own field', () => {
+      expect(
+        normalizeOsFields({
+          os: 'Android',
+          osVersion: '16',
+          osApiLevel: 36,
+          osBuildFingerprint: FP_16,
+        }),
+      ).toEqual({
+        osVersion: '16',
+        osApiLevel: 36,
+        osBuildFingerprint: FP_16,
+        os: 'Android',
+      })
+    })
+
+    it('prefers the reported build string over one parsed out of os', () => {
+      const patch = normalizeOsFields({ os: FP_14, osBuildFingerprint: FP_16 })
+      expect(patch.osBuildFingerprint).toBe(FP_16)
+    })
+
+    it('emits no build string when the reported one is blank', () => {
+      // BASE_OS is empty on many devices, and '' is not null, so it would
+      // otherwise reach $set.
+      for (const blank of ['', '   ']) {
+        const patch = normalizeOsFields({ os: 'Android', osBuildFingerprint: blank })
+        expect(patch).not.toHaveProperty('osBuildFingerprint')
+      }
+    })
+
+    it('falls back to os when no build string is reported', () => {
+      expect(normalizeOsFields({ os: FP_14 }).osBuildFingerprint).toBe(FP_14)
+    })
   })
 
   describe('partial payloads', () => {

--- a/api/src/gateway/os-version.ts
+++ b/api/src/gateway/os-version.ts
@@ -45,7 +45,15 @@ export function normalizeOsFields(input: OsFieldsInput): Record<string, any> {
     patch.osApiLevel = input.osApiLevel
   }
 
-  if (raw && raw.includes('/')) patch.osBuildFingerprint = raw
+  // Current clients send the build string in its own field, since `os` now
+  // carries the plain 'Android' label. Older clients only ever put it in `os`.
+  const reportedFingerprint = input?.osBuildFingerprint?.trim()
+  if (reportedFingerprint) {
+    patch.osBuildFingerprint = reportedFingerprint
+  } else if (raw && raw.includes('/')) {
+    patch.osBuildFingerprint = raw
+  }
+
   if (input?.os !== undefined) patch.os = 'Android'
 
   return patch


### PR DESCRIPTION
Follow-up to #298.

## Problem

The auto-fix commit in #298 closed a real hole: raw OS metadata was reaching `$set` through the input spread, so an empty string or a null could blank a stored `osVersion`, `osApiLevel`, or `osBuildFingerprint`. Stripping those raw fields before merging the normalized patch was the right call and stays.

It also added `osBuildFingerprint` to `OsFieldsInput`, but `normalizeOsFields` never reads it. That left the interface advertising a field the function ignores.

Combined, those two changes drop the value. Current clients send `os` as the plain `Android` label and put the build string in its own field, so there is no `/` in `os` to parse:

```
sent      -> {"os":"Android","osVersion":"16","osApiLevel":36,"osBuildFingerprint":"samsung/e3qxxx/e3q:16/BP2A..."}
persisted -> {"osVersion":"16","osApiLevel":36,"os":"Android"}
```

`osBuildFingerprint` became writable only by the backfill script. No app build could populate it, and the per-OEM detail that #298 deliberately moved into that field was lost. The admin tooltip falls back to `os`, which is now the literal string `Android`, so the detail disappeared from the UI too.

Not data destroying: an absent key means `$set` leaves the stored value alone, so anything already written survives. It is a silent write-path gap.

## Change

`normalizeOsFields` now emits a reported build string when it is non blank, and still falls back to parsing one out of `os` for older clients that only ever sent it there.

```ts
const reportedFingerprint = input?.osBuildFingerprint?.trim()
if (reportedFingerprint) {
  patch.osBuildFingerprint = reportedFingerprint
} else if (raw && raw.includes('/')) {
  patch.osBuildFingerprint = raw
}
```

A blank reported value still emits no key, so it cannot overwrite what is stored.

## Tests

Three of the added tests fail without the one-line source change, verified by reverting it and re-running.

Also added coverage for the behavior the auto-fix introduced, which nothing pinned down: a parameterised case asserting that `osVersion: ""`, `osApiLevel: null`, and `osBuildFingerprint: ""` each leave the stored value alone. Worth having explicitly, since the gateway API is public and has no `ValidationPipe`, so those payloads can arrive from any client rather than only the Android app.

245 passed, 16 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)