### PR TITLE
Document every API endpoint and export a curated public OpenAPI spec

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1,0 +1,2118 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/v1/gateway/stats": {
+      "get": {
+        "description": "Messages sent, messages received, devices, and API keys across your whole account.",
+        "operationId": "GatewayController_getStats_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Account totals.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayStatsResponseDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Get account totals",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
+    "/api/v1/gateway/devices": {
+      "get": {
+        "description": "Every phone paired with your account. The push token and hardware serial are never returned.",
+        "operationId": "GatewayController_getDevices_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Your devices.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceListResponseDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "List your devices",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
+    "/api/v1/gateway/devices/{id}": {
+      "get": {
+        "description": "Full state of one device, including its last heartbeat, battery, and SIM list.",
+        "operationId": "GatewayController_getDevice_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Device id, from GET /gateway/devices.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The device.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The device id is not a valid id."
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "404": {
+            "description": "No device with that id on your account."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Get a device",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
+    "/api/v1/gateway/send-sms": {
+      "post": {
+        "description": "Sends one message to one or more recipients from a phone on your account. deviceId is optional: without it textbee uses your default device, otherwise the enabled device with the most recent heartbeat. Every recipient counts as one message against your plan.",
+        "operationId": "GatewayController_sendSMSDeviceless_v1",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendSMSRequestDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The send was accepted. Use smsBatchId to follow delivery. Acceptance is not delivery: the phone still has to be online.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendSMSResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No enabled device to send from, the device is disabled, your email is not verified, or the message could not be pushed to the phone."
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "429": {
+            "description": "Your daily, monthly, or per-batch plan limit is used up. The body says which one."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Send an SMS",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
+    "/api/v1/gateway/send-bulk-sms": {
+      "post": {
+        "description": "Sends a batch where every entry has its own text and recipients. deviceId is optional and resolves the same way as POST /gateway/send-sms.",
+        "operationId": "GatewayController_sendBulkSMSDeviceless_v1",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendBulkSMSRequestDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The batch was accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendSMSResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No enabled device to send from, the device is disabled, your email is not verified, or the batch could not be pushed to the phone."
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "429": {
+            "description": "Your daily, monthly, or per-batch plan limit is used up. The body says which one."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Send several SMS in one call",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
+    "/api/v1/gateway/devices/{id}/messages": {
+      "get": {
+        "description": "Sent and received messages for one device, newest first, with delivery status on each. This is the endpoint to poll for new messages.",
+        "operationId": "GatewayController_getMessages_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Device id, from GET /gateway/devices.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "Match against the message text and the other party number. Encrypted messages cannot be searched.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Direction to return. Default all.",
+            "schema": {
+              "enum": [
+                "all",
+                "sent",
+                "received"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Messages per page. Default 50, maximum 100.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page to return. Default 1.",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of messages.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetrieveSMSResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The device id is not a valid id."
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "404": {
+            "description": "No device with that id on your account."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "List message history",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
+    "/api/v1/gateway/devices/{id}/sms/{smsId}": {
+      "get": {
+        "description": "A single sent or received message with its delivery timestamps. Use it to check the outcome of one recipient.",
+        "operationId": "GatewayController_getSMSById_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Device id, from GET /gateway/devices.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "smsId",
+            "required": true,
+            "in": "path",
+            "description": "Message id, from the message history response.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The message.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SMSResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The device id is not a valid id."
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "404": {
+            "description": "No such message on this device."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Get one message",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
+    "/api/v1/gateway/devices/{id}/sms-batch/{smsBatchId}": {
+      "get": {
+        "description": "The batch returned by a send, plus one message per recipient. Poll this to see how a send is progressing.",
+        "operationId": "GatewayController_getSmsBatchById_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Device id, from GET /gateway/devices.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "smsBatchId",
+            "required": true,
+            "in": "path",
+            "description": "Batch id, returned as smsBatchId by the send endpoints.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The batch and its messages.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SMSBatchResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The device id is not a valid id."
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "404": {
+            "description": "No such batch on this device."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Get a send batch",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
+    "/api/v1/webhooks": {
+      "get": {
+        "description": "Every subscription on your account, deleted ones excluded. Each one says which events it receives and where they are delivered.",
+        "operationId": "WebhookController_getWebhooks_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Your subscriptions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookListResponseDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "List your webhook subscriptions",
+        "tags": [
+          "webhooks"
+        ]
+      },
+      "post": {
+        "description": "textbee POSTs the events you pick to your delivery URL and signs each request with your signing secret, sent as the X-Signature header. Failed deliveries are retried up to 10 times, and a subscription that keeps failing is paused.",
+        "operationId": "WebhookController_createWebhook_v1",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWebhookDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The subscription was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The delivery URL is unusable, the signing secret is shorter than 20 characters, the event list is empty or unknown, or you already have the maximum number of subscriptions."
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Create a webhook subscription",
+        "tags": [
+          "webhooks"
+        ]
+      }
+    },
+    "/api/v1/webhooks/notifications": {
+      "get": {
+        "description": "Delivery history across your subscriptions, newest first. Use it to see what textbee sent, what your endpoint answered, and whether a retry is pending. History is kept for subscriptions you have since deleted.",
+        "operationId": "WebhookController_getWebhookNotifications_v1",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page to return. Default 1.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Records per page. Default 10.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "status",
+            "required": false,
+            "in": "query",
+            "description": "Only return deliveries in this state.",
+            "schema": {
+              "enum": [
+                "pending",
+                "retrying",
+                "delivered",
+                "failed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "eventType",
+            "required": false,
+            "in": "query",
+            "description": "Only return deliveries for this event.",
+            "schema": {
+              "enum": [
+                "MESSAGE_RECEIVED",
+                "MESSAGE_SENT",
+                "MESSAGE_DELIVERED",
+                "MESSAGE_FAILED",
+                "UNKNOWN_STATE",
+                "SMS_STATUS_UPDATED"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "deviceId",
+            "required": false,
+            "in": "query",
+            "description": "Only return deliveries for messages from this device.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start",
+            "required": false,
+            "in": "query",
+            "description": "Start of the time range, ISO 8601. Applied only together with end.",
+            "schema": {
+              "example": "2026-08-01T00:00:00Z",
+              "type": "string"
+            }
+          },
+          {
+            "name": "end",
+            "required": false,
+            "in": "query",
+            "description": "End of the time range, ISO 8601.",
+            "schema": {
+              "example": "2026-08-31T23:59:59Z",
+              "type": "string"
+            }
+          },
+          {
+            "name": "webhookSubscriptionId",
+            "required": false,
+            "in": "query",
+            "description": "Only return deliveries for one subscription.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of delivery records.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookNotificationListResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "deviceId or webhookSubscriptionId is not a valid id."
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "404": {
+            "description": "No webhook subscription with that id on your account."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "List webhook delivery attempts",
+        "tags": [
+          "webhooks"
+        ]
+      }
+    },
+    "/api/v1/webhooks/{webhookId}": {
+      "get": {
+        "description": "One subscription with its delivery counters.",
+        "operationId": "WebhookController_getWebhook_v1",
+        "parameters": [
+          {
+            "name": "webhookId",
+            "required": true,
+            "in": "path",
+            "description": "Subscription id, from GET /webhooks.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The subscription.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookResponseDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "404": {
+            "description": "No webhook subscription with that id on your account."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Get a webhook subscription",
+        "tags": [
+          "webhooks"
+        ]
+      },
+      "patch": {
+        "description": "Changes only the fields you send. Use isActive to re-enable a subscription textbee paused after repeated failures.",
+        "operationId": "WebhookController_updateWebhook_v1",
+        "parameters": [
+          {
+            "name": "webhookId",
+            "required": true,
+            "in": "path",
+            "description": "Subscription id, from GET /webhooks.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWebhookDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated subscription.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The delivery URL is unusable, the signing secret is shorter than 20 characters, or the event list is empty or unknown."
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "404": {
+            "description": "No webhook subscription with that id on your account."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Update a webhook subscription",
+        "tags": [
+          "webhooks"
+        ]
+      },
+      "delete": {
+        "description": "Stops all deliveries for this subscription. Its delivery history stays readable through GET /webhooks/notifications.",
+        "operationId": "WebhookController_deleteWebhook_v1",
+        "parameters": [
+          {
+            "name": "webhookId",
+            "required": true,
+            "in": "path",
+            "description": "Subscription id, from GET /webhooks.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The subscription was deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookDeletedResponseDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing, invalid, or revoked API key."
+          },
+          "404": {
+            "description": "No webhook subscription with that id on your account."
+          }
+        },
+        "security": [
+          {
+            "x-api-key": []
+          }
+        ],
+        "summary": "Delete a webhook subscription",
+        "tags": [
+          "webhooks"
+        ]
+      }
+    }
+  },
+  "info": {
+    "title": "textbee API",
+    "description": "Send and receive SMS through an Android phone you own. Authenticate every request with an API key from your textbee dashboard, sent as the x-api-key header.",
+    "version": "1.0",
+    "contact": {},
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/vernu/textbee/blob/main/LICENSE"
+    }
+  },
+  "tags": [
+    {
+      "name": "gateway",
+      "description": "Send SMS and read message history through the Android devices paired with your account."
+    },
+    {
+      "name": "webhooks",
+      "description": "Subscribe to SMS events and inspect the delivery attempts textbee made for them."
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://api.textbee.dev"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "x-api-key": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key",
+        "description": "API key from your textbee dashboard, sent on every request."
+      }
+    },
+    "schemas": {
+      "GatewayStatsDTO": {
+        "type": "object",
+        "properties": {
+          "totalSentSMSCount": {
+            "type": "number",
+            "description": "Messages sent across all your devices."
+          },
+          "totalReceivedSMSCount": {
+            "type": "number",
+            "description": "Messages received across all your devices."
+          },
+          "totalDeviceCount": {
+            "type": "number",
+            "description": "Devices on your account."
+          },
+          "totalApiKeyCount": {
+            "type": "number",
+            "description": "API keys on your account."
+          }
+        },
+        "required": [
+          "totalSentSMSCount",
+          "totalReceivedSMSCount",
+          "totalDeviceCount",
+          "totalApiKeyCount"
+        ]
+      },
+      "GatewayStatsResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/GatewayStatsDTO"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "SimInfoDTO": {
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "number",
+            "description": "Android subscription id of the SIM. Pass it as simSubscriptionId when sending to choose this SIM.",
+            "example": 1
+          },
+          "iccId": {
+            "type": "string",
+            "description": "ICCID of the SIM card."
+          },
+          "cardId": {
+            "type": "number",
+            "description": "Android card id of the SIM slot."
+          },
+          "carrierName": {
+            "type": "string",
+            "description": "Mobile network operator, as reported by Android.",
+            "example": "Safaricom"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Label the user gave this SIM on the device."
+          },
+          "simSlotIndex": {
+            "type": "number",
+            "description": "Physical SIM slot, starting at 0.",
+            "example": 0
+          },
+          "mcc": {
+            "type": "string",
+            "description": "Mobile country code.",
+            "example": "639"
+          },
+          "mnc": {
+            "type": "string",
+            "description": "Mobile network code.",
+            "example": "02"
+          },
+          "countryIso": {
+            "type": "string",
+            "description": "Two letter country code of the SIM.",
+            "example": "ke"
+          },
+          "subscriptionType": {
+            "type": "string",
+            "description": "Whether the SIM is physical or an eSIM.",
+            "enum": [
+              "PHYSICAL_SIM",
+              "ESIM"
+            ]
+          }
+        },
+        "required": [
+          "subscriptionId"
+        ]
+      },
+      "SimInfoCollectionDTO": {
+        "type": "object",
+        "properties": {
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the device last reported its SIM list."
+          },
+          "sims": {
+            "description": "SIMs currently installed in the device.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SimInfoDTO"
+            }
+          }
+        },
+        "required": [
+          "lastUpdated",
+          "sims"
+        ]
+      },
+      "BatteryInfoDTO": {
+        "type": "object",
+        "properties": {
+          "percentage": {
+            "type": "number",
+            "description": "Battery level, 0 to 100."
+          },
+          "isCharging": {
+            "type": "boolean",
+            "description": "Whether the device was charging at the last heartbeat."
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When this reading was taken."
+          }
+        }
+      },
+      "NetworkInfoDTO": {
+        "type": "object",
+        "properties": {
+          "networkType": {
+            "type": "string",
+            "enum": [
+              "wifi",
+              "cellular",
+              "none"
+            ],
+            "description": "Connection the device last reported."
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When this reading was taken."
+          }
+        }
+      },
+      "AppVersionInfoDTO": {
+        "type": "object",
+        "properties": {
+          "versionName": {
+            "type": "string",
+            "description": "textbee app version name.",
+            "example": "1.9.0"
+          },
+          "versionCode": {
+            "type": "number",
+            "description": "textbee app version code.",
+            "example": 190
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When this reading was taken."
+          }
+        }
+      },
+      "DeviceUptimeInfoDTO": {
+        "type": "object",
+        "properties": {
+          "uptimeMillis": {
+            "type": "number",
+            "description": "Milliseconds since the device booted."
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When this reading was taken."
+          }
+        }
+      },
+      "MemoryInfoDTO": {
+        "type": "object",
+        "properties": {
+          "freeBytes": {
+            "type": "number",
+            "description": "Free memory in bytes."
+          },
+          "totalBytes": {
+            "type": "number",
+            "description": "Total memory in bytes."
+          },
+          "maxBytes": {
+            "type": "number",
+            "description": "Maximum memory the app may use, in bytes."
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When this reading was taken."
+          }
+        }
+      },
+      "StorageInfoDTO": {
+        "type": "object",
+        "properties": {
+          "availableBytes": {
+            "type": "number",
+            "description": "Free storage in bytes."
+          },
+          "totalBytes": {
+            "type": "number",
+            "description": "Total storage in bytes."
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When this reading was taken."
+          }
+        }
+      },
+      "DeviceSystemInfoDTO": {
+        "type": "object",
+        "properties": {
+          "timezone": {
+            "type": "string",
+            "description": "Device timezone.",
+            "example": "Africa/Addis_Ababa"
+          },
+          "locale": {
+            "type": "string",
+            "description": "Device locale.",
+            "example": "en_US"
+          },
+          "lastUpdated": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When this reading was taken."
+          }
+        }
+      },
+      "DeviceDTO": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "Device id. Pass it as deviceId when sending."
+          },
+          "user": {
+            "type": "string",
+            "description": "Owner account id."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the device may send and receive SMS. Sending to a disabled device fails."
+          },
+          "isDefault": {
+            "type": "boolean",
+            "description": "Whether sends without a deviceId go out from this device."
+          },
+          "brand": {
+            "type": "string",
+            "description": "Device brand.",
+            "example": "google"
+          },
+          "manufacturer": {
+            "type": "string",
+            "description": "Device manufacturer.",
+            "example": "Google"
+          },
+          "model": {
+            "type": "string",
+            "description": "Device model.",
+            "example": "Pixel 7"
+          },
+          "name": {
+            "type": "string",
+            "description": "Your own label for the device.",
+            "example": "Office phone"
+          },
+          "buildId": {
+            "type": "string",
+            "description": "Android build id."
+          },
+          "os": {
+            "type": "string",
+            "description": "Operating system name.",
+            "example": "Android"
+          },
+          "osVersion": {
+            "type": "string",
+            "description": "Android release version.",
+            "example": "16"
+          },
+          "osApiLevel": {
+            "type": "number",
+            "description": "Android SDK level.",
+            "example": 36
+          },
+          "osVersionSource": {
+            "type": "string",
+            "enum": [
+              "reported",
+              "fingerprint",
+              "buildId"
+            ],
+            "description": "How osVersion was determined."
+          },
+          "osBuildFingerprint": {
+            "type": "string",
+            "description": "Android build fingerprint."
+          },
+          "appVersionName": {
+            "type": "string",
+            "description": "textbee app version name.",
+            "example": "1.9.0"
+          },
+          "appVersionCode": {
+            "type": "number",
+            "description": "textbee app version code.",
+            "example": 190
+          },
+          "sentSMSCount": {
+            "type": "number",
+            "description": "Messages this device has sent."
+          },
+          "receivedSMSCount": {
+            "type": "number",
+            "description": "Messages this device has received."
+          },
+          "heartbeatEnabled": {
+            "type": "boolean",
+            "description": "Whether the device reports heartbeats."
+          },
+          "heartbeatIntervalMinutes": {
+            "type": "number",
+            "description": "Minutes between heartbeats.",
+            "example": 30
+          },
+          "receiveSMSEnabled": {
+            "type": "boolean",
+            "description": "Whether incoming messages are forwarded to textbee. Required for received message history and webhooks."
+          },
+          "smsSendDelaySeconds": {
+            "type": "number",
+            "description": "Seconds the device waits between messages in a batch."
+          },
+          "lastHeartbeat": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Last heartbeat. A device silent for long is likely offline and sends will queue."
+          },
+          "batteryInfo": {
+            "$ref": "#/components/schemas/BatteryInfoDTO"
+          },
+          "networkInfo": {
+            "$ref": "#/components/schemas/NetworkInfoDTO"
+          },
+          "appVersionInfo": {
+            "$ref": "#/components/schemas/AppVersionInfoDTO"
+          },
+          "deviceUptimeInfo": {
+            "$ref": "#/components/schemas/DeviceUptimeInfoDTO"
+          },
+          "memoryInfo": {
+            "$ref": "#/components/schemas/MemoryInfoDTO"
+          },
+          "storageInfo": {
+            "$ref": "#/components/schemas/StorageInfoDTO"
+          },
+          "systemInfo": {
+            "$ref": "#/components/schemas/DeviceSystemInfoDTO"
+          },
+          "simInfo": {
+            "description": "SIMs installed in the device.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SimInfoCollectionDTO"
+              }
+            ]
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the device was registered."
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the device was last updated."
+          }
+        },
+        "required": [
+          "_id",
+          "user",
+          "enabled",
+          "isDefault",
+          "brand",
+          "manufacturer",
+          "model",
+          "buildId",
+          "os",
+          "osVersion",
+          "sentSMSCount",
+          "receivedSMSCount",
+          "heartbeatEnabled",
+          "heartbeatIntervalMinutes",
+          "receiveSMSEnabled",
+          "smsSendDelaySeconds",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "DeviceResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DeviceDTO"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "DeviceListResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviceDTO"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "SendSMSRequestDTO": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text of the message. Long messages are split by the carrier.",
+            "example": "Your appointment is confirmed for Tuesday at 10am."
+          },
+          "recipients": {
+            "description": "Phone numbers to send to, in international format. Each recipient is billed as one message.",
+            "example": [
+              "+2519xxxxxxxx",
+              "+2517xxxxxxxx"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "simSubscriptionId": {
+            "type": "number",
+            "description": "SIM to send from, as subscriptionId from the device simInfo. Defaults to the device default SIM.",
+            "example": 1
+          },
+          "scheduledAt": {
+            "type": "string",
+            "description": "ISO 8601 time to send the message. Must be in the future. Omit to send now.",
+            "example": "2024-01-15T10:30:00Z"
+          },
+          "smsBody": {
+            "type": "string",
+            "deprecated": true,
+            "description": "Legacy alias for message. Used only when message is absent."
+          },
+          "receivers": {
+            "deprecated": true,
+            "description": "Legacy alias for recipients. Used only when recipients is absent.",
+            "example": [
+              "+2519xxxxxxxx",
+              "+2517xxxxxxxx"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "deviceId": {
+            "type": "string",
+            "description": "Device to send from. When omitted, uses your default device, or the enabled device with the most recent heartbeat."
+          }
+        },
+        "required": [
+          "message",
+          "recipients"
+        ]
+      },
+      "SendSMSResultDTO": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the batch was accepted. Queued sends only."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human readable outcome. Queued sends only.",
+            "example": "SMS added to queue for processing"
+          },
+          "smsBatchId": {
+            "type": "string",
+            "description": "Batch id. Pass it to GET /gateway/devices/{id}/sms-batch/{smsBatchId} to follow delivery. Queued sends only."
+          },
+          "recipientCount": {
+            "type": "number",
+            "description": "Number of recipients in the batch. Queued sends only."
+          },
+          "successCount": {
+            "type": "number",
+            "description": "Messages pushed to the device. Returned instead of the queue fields when the instance dispatches immediately."
+          },
+          "failureCount": {
+            "type": "number",
+            "description": "Messages that could not be pushed to the device."
+          }
+        }
+      },
+      "SendSMSResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SendSMSResultDTO"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "SMSData": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text of the message. Long messages are split by the carrier.",
+            "example": "Your appointment is confirmed for Tuesday at 10am."
+          },
+          "recipients": {
+            "description": "Phone numbers to send to, in international format. Each recipient is billed as one message.",
+            "example": [
+              "+2519xxxxxxxx",
+              "+2517xxxxxxxx"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "simSubscriptionId": {
+            "type": "number",
+            "description": "SIM to send from, as subscriptionId from the device simInfo. Defaults to the device default SIM.",
+            "example": 1
+          },
+          "scheduledAt": {
+            "type": "string",
+            "description": "ISO 8601 time to send the message. Must be in the future. Omit to send now.",
+            "example": "2024-01-15T10:30:00Z"
+          },
+          "smsBody": {
+            "type": "string",
+            "deprecated": true,
+            "description": "Legacy alias for message. Used only when message is absent."
+          },
+          "receivers": {
+            "deprecated": true,
+            "description": "Legacy alias for recipients. Used only when recipients is absent.",
+            "example": [
+              "+2519xxxxxxxx",
+              "+2517xxxxxxxx"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "message",
+          "recipients"
+        ]
+      },
+      "SendBulkSMSRequestDTO": {
+        "type": "object",
+        "properties": {
+          "messageTemplate": {
+            "type": "string",
+            "description": "Optional label for the batch. Each entry in messages carries its own text."
+          },
+          "messages": {
+            "description": "Messages to send. Every message can target different recipients and use a different SIM.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SMSData"
+            }
+          },
+          "deviceId": {
+            "type": "string",
+            "description": "Device to send from. When omitted, uses your default device, or the enabled device with the most recent heartbeat."
+          }
+        },
+        "required": [
+          "messages"
+        ]
+      },
+      "MessageDeviceDTO": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "Device id."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the device may send and receive SMS."
+          },
+          "brand": {
+            "type": "string",
+            "description": "Device brand.",
+            "example": "google"
+          },
+          "model": {
+            "type": "string",
+            "description": "Device model.",
+            "example": "Pixel 7"
+          },
+          "buildId": {
+            "type": "string",
+            "description": "Android build id."
+          }
+        },
+        "required": [
+          "_id",
+          "enabled",
+          "brand",
+          "model",
+          "buildId"
+        ]
+      },
+      "RetrieveSMSDTO": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "Message id."
+          },
+          "message": {
+            "type": "string",
+            "description": "Message text. Empty when the message is end to end encrypted."
+          },
+          "device": {
+            "description": "Device that sent or received the message.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageDeviceDTO"
+              }
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "sent",
+              "received"
+            ],
+            "description": "Direction of the message."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "dispatched",
+              "sent",
+              "delivered",
+              "failed",
+              "unknown",
+              "received"
+            ],
+            "description": "Delivery state. Incoming messages are always received. Outgoing messages move from pending to sent, then to delivered when the carrier confirms."
+          },
+          "sender": {
+            "type": "string",
+            "description": "Sender number. Set on received messages."
+          },
+          "recipient": {
+            "type": "string",
+            "description": "Destination number. Set on sent messages."
+          },
+          "smsBatch": {
+            "type": "string",
+            "description": "Id of the batch this message was sent in."
+          },
+          "encrypted": {
+            "type": "boolean",
+            "description": "Whether the body is end to end encrypted. Encrypted bodies can only be read by your own client."
+          },
+          "simSubscriptionId": {
+            "type": "number",
+            "description": "SIM the message was sent from."
+          },
+          "receivedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the message was received. Received messages only."
+          },
+          "requestedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the send was requested. Sent messages only."
+          },
+          "dispatchedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the send job reached the device."
+          },
+          "sentAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the device reported the message as sent."
+          },
+          "deliveredAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the carrier confirmed delivery."
+          },
+          "failedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the message failed."
+          },
+          "errorCode": {
+            "type": "string",
+            "description": "Failure code reported by the device."
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "Failure reason reported by the device."
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the record was created."
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the record was last updated."
+          }
+        },
+        "required": [
+          "_id",
+          "device",
+          "type",
+          "status",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "PaginationMetaDTO": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Current page number"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of items per page"
+          },
+          "total": {
+            "type": "number",
+            "description": "Total number of items"
+          },
+          "totalPages": {
+            "type": "number",
+            "description": "Total number of pages"
+          }
+        },
+        "required": [
+          "page",
+          "limit",
+          "total",
+          "totalPages"
+        ]
+      },
+      "RetrieveSMSResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "The received SMS data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RetrieveSMSDTO"
+            }
+          },
+          "meta": {
+            "description": "Pagination metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationMetaDTO"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "SMSResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/RetrieveSMSDTO"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "SMSBatchDTO": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "Batch id."
+          },
+          "user": {
+            "type": "string",
+            "description": "Owner account id."
+          },
+          "message": {
+            "type": "string",
+            "description": "Message text sent to every recipient in the batch."
+          },
+          "encrypted": {
+            "type": "boolean",
+            "description": "Whether the body is end to end encrypted."
+          },
+          "recipientCount": {
+            "type": "number",
+            "description": "Recipients in the batch."
+          },
+          "recipientPreview": {
+            "type": "string",
+            "description": "Short preview of the recipient list.",
+            "example": "+2519xxxxxxxx and 3 others"
+          },
+          "successCount": {
+            "type": "number",
+            "description": "Messages sent so far."
+          },
+          "failureCount": {
+            "type": "number",
+            "description": "Messages that failed."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "processing",
+              "completed",
+              "partial_success",
+              "failed",
+              "unknown"
+            ],
+            "description": "Progress of the batch as a whole."
+          },
+          "error": {
+            "type": "string",
+            "description": "Failure reason when the batch failed."
+          },
+          "completedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the batch finished."
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the batch was created."
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the batch was last updated."
+          }
+        },
+        "required": [
+          "_id",
+          "user",
+          "recipientCount",
+          "successCount",
+          "failureCount",
+          "status",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "SMSBatchResultDTO": {
+        "type": "object",
+        "properties": {
+          "batch": {
+            "description": "The batch itself.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SMSBatchDTO"
+              }
+            ]
+          },
+          "messages": {
+            "description": "Every message in the batch, one per recipient.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RetrieveSMSDTO"
+            }
+          }
+        },
+        "required": [
+          "batch",
+          "messages"
+        ]
+      },
+      "SMSBatchResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SMSBatchResultDTO"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "WebhookNoteDTO": {
+        "type": "object",
+        "properties": {
+          "at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the note was added."
+          },
+          "text": {
+            "type": "string",
+            "description": "What textbee recorded, for example why the subscription was paused."
+          }
+        },
+        "required": [
+          "at",
+          "text"
+        ]
+      },
+      "WebhookSubscriptionDTO": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "Subscription id."
+          },
+          "user": {
+            "type": "string",
+            "description": "Owner account id."
+          },
+          "name": {
+            "type": "string",
+            "description": "Label shown in the dashboard."
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether deliveries are attempted. textbee pauses subscriptions that keep failing."
+          },
+          "events": {
+            "type": "array",
+            "description": "Events this subscription receives.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "MESSAGE_RECEIVED",
+                "MESSAGE_SENT",
+                "MESSAGE_DELIVERED",
+                "MESSAGE_FAILED",
+                "UNKNOWN_STATE",
+                "SMS_STATUS_UPDATED"
+              ]
+            }
+          },
+          "deliveryUrl": {
+            "type": "string",
+            "description": "URL events are POSTed to."
+          },
+          "signingSecret": {
+            "type": "string",
+            "description": "Secret used to sign deliveries."
+          },
+          "successfulDeliveryCount": {
+            "type": "number",
+            "description": "Deliveries that succeeded."
+          },
+          "deliveryFailureCount": {
+            "type": "number",
+            "description": "Deliveries that failed."
+          },
+          "deliveryAttemptCount": {
+            "type": "number",
+            "description": "Delivery attempts made, retries included."
+          },
+          "lastDeliveryAttemptAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Last time a delivery was attempted."
+          },
+          "lastDeliverySuccessAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Last time a delivery succeeded."
+          },
+          "lastDeliveryFailureAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Last time a delivery failed."
+          },
+          "notes": {
+            "description": "Notes textbee added, such as an auto-pause reason.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookNoteDTO"
+            }
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the subscription was created."
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When it was last updated."
+          }
+        },
+        "required": [
+          "_id",
+          "user",
+          "isActive",
+          "events",
+          "deliveryUrl",
+          "signingSecret",
+          "successfulDeliveryCount",
+          "deliveryFailureCount",
+          "deliveryAttemptCount",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "WebhookListResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "Your webhook subscriptions. Deleted ones are not returned.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookSubscriptionDTO"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "WebhookNotificationDTO": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "description": "Delivery record id."
+          },
+          "webhookSubscription": {
+            "type": "string",
+            "description": "Subscription this belongs to."
+          },
+          "event": {
+            "type": "string",
+            "enum": [
+              "MESSAGE_RECEIVED",
+              "MESSAGE_SENT",
+              "MESSAGE_DELIVERED",
+              "MESSAGE_FAILED",
+              "UNKNOWN_STATE",
+              "SMS_STATUS_UPDATED"
+            ],
+            "description": "Event that was delivered."
+          },
+          "payload": {
+            "type": "object",
+            "description": "Exact JSON body textbee POSTed to your endpoint."
+          },
+          "computedStatus": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "retrying",
+              "delivered",
+              "failed"
+            ],
+            "description": "Delivery state. Retrying means textbee will try again, failed means it gave up after 10 attempts."
+          },
+          "deliveryUrl": {
+            "type": "string",
+            "description": "URL the delivery was sent to when it was attempted."
+          },
+          "deliveryAttemptCount": {
+            "type": "number",
+            "description": "Attempts made for this event."
+          },
+          "deliveredAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When your endpoint accepted the delivery."
+          },
+          "lastDeliveryAttemptAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the last attempt was made."
+          },
+          "nextDeliveryAttemptAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the next retry is due."
+          },
+          "deliveryAttemptAbortedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When textbee stopped retrying."
+          },
+          "errorType": {
+            "type": "string",
+            "enum": [
+              "retryable",
+              "non-retryable"
+            ],
+            "description": "Whether the failure is worth retrying."
+          },
+          "httpStatusCode": {
+            "type": "number",
+            "description": "Status code your endpoint returned on the last attempt."
+          },
+          "responseBody": {
+            "type": "string",
+            "description": "First 1000 characters of your endpoint response."
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Idempotency key sent with the delivery."
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the event was recorded."
+          }
+        },
+        "required": [
+          "_id",
+          "webhookSubscription",
+          "event",
+          "payload",
+          "computedStatus",
+          "deliveryAttemptCount",
+          "createdAt"
+        ]
+      },
+      "WebhookNotificationPageDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "Delivery records, newest first.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookNotificationDTO"
+            }
+          },
+          "meta": {
+            "description": "Pagination info.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationMetaDTO"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "WebhookNotificationListResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WebhookNotificationPageDTO"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "WebhookResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WebhookSubscriptionDTO"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "CreateWebhookDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Label shown in the dashboard. Up to 64 characters.",
+            "example": "Order notifications"
+          },
+          "deliveryUrl": {
+            "type": "string",
+            "description": "URL textbee POSTs events to. Must be http or https and publicly reachable. Private and loopback hosts are rejected.",
+            "example": "https://example.com/textbee/webhook"
+          },
+          "signingSecret": {
+            "type": "string",
+            "description": "Shared secret, at least 20 characters. textbee signs every delivery with it and sends the signature in the X-Signature header, so your endpoint can verify the request really came from textbee."
+          },
+          "events": {
+            "type": "array",
+            "description": "Events to deliver. At least one is required.",
+            "example": [
+              "MESSAGE_RECEIVED"
+            ],
+            "items": {
+              "type": "string",
+              "enum": [
+                "MESSAGE_RECEIVED",
+                "MESSAGE_SENT",
+                "MESSAGE_DELIVERED",
+                "MESSAGE_FAILED",
+                "UNKNOWN_STATE",
+                "SMS_STATUS_UPDATED"
+              ]
+            }
+          }
+        },
+        "required": [
+          "deliveryUrl",
+          "signingSecret",
+          "events"
+        ]
+      },
+      "UpdateWebhookDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Label shown in the dashboard. Up to 64 characters.",
+            "example": "Order notifications"
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether deliveries are attempted. Set it to true to re-enable a subscription textbee paused after repeated failures."
+          },
+          "deliveryUrl": {
+            "type": "string",
+            "description": "New delivery URL. Same rules as on create: http or https, no private or loopback hosts.",
+            "example": "https://example.com/textbee/webhook"
+          },
+          "signingSecret": {
+            "type": "string",
+            "description": "New signing secret, at least 20 characters."
+          },
+          "events": {
+            "type": "array",
+            "description": "Replacement event list. Cannot be empty.",
+            "example": [
+              "MESSAGE_RECEIVED",
+              "MESSAGE_DELIVERED"
+            ],
+            "items": {
+              "type": "string",
+              "enum": [
+                "MESSAGE_RECEIVED",
+                "MESSAGE_SENT",
+                "MESSAGE_DELIVERED",
+                "MESSAGE_FAILED",
+                "UNKNOWN_STATE",
+                "SMS_STATUS_UPDATED"
+              ]
+            }
+          }
+        }
+      },
+      "WebhookDeletedResultDTO": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the delete succeeded."
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
+      "WebhookDeletedResponseDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/WebhookDeletedResultDTO"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      }
+    }
+  }
+}

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -811,7 +811,12 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/GatewayStatsDTO"
+            "description": "Account totals.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GatewayStatsDTO"
+              }
+            ]
           }
         },
         "required": [
@@ -1140,25 +1145,60 @@
             "description": "Last heartbeat. A device silent for long is likely offline and sends will queue."
           },
           "batteryInfo": {
-            "$ref": "#/components/schemas/BatteryInfoDTO"
+            "description": "Battery level at the last heartbeat.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BatteryInfoDTO"
+              }
+            ]
           },
           "networkInfo": {
-            "$ref": "#/components/schemas/NetworkInfoDTO"
+            "description": "Connection the device was on at the last heartbeat.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NetworkInfoDTO"
+              }
+            ]
           },
           "appVersionInfo": {
-            "$ref": "#/components/schemas/AppVersionInfoDTO"
+            "description": "textbee app version running on the device.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AppVersionInfoDTO"
+              }
+            ]
           },
           "deviceUptimeInfo": {
-            "$ref": "#/components/schemas/DeviceUptimeInfoDTO"
+            "description": "How long the device has been up.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviceUptimeInfoDTO"
+              }
+            ]
           },
           "memoryInfo": {
-            "$ref": "#/components/schemas/MemoryInfoDTO"
+            "description": "Memory reported at the last heartbeat.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MemoryInfoDTO"
+              }
+            ]
           },
           "storageInfo": {
-            "$ref": "#/components/schemas/StorageInfoDTO"
+            "description": "Storage reported at the last heartbeat.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StorageInfoDTO"
+              }
+            ]
           },
           "systemInfo": {
-            "$ref": "#/components/schemas/DeviceSystemInfoDTO"
+            "description": "Timezone and locale of the device.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviceSystemInfoDTO"
+              }
+            ]
           },
           "simInfo": {
             "description": "SIMs installed in the device.",
@@ -1204,7 +1244,12 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/DeviceDTO"
+            "description": "The device.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviceDTO"
+              }
+            ]
           }
         },
         "required": [
@@ -1215,6 +1260,7 @@
         "type": "object",
         "properties": {
           "data": {
+            "description": "Your devices.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/DeviceDTO"
@@ -1315,7 +1361,12 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/SendSMSResultDTO"
+            "description": "Outcome of the send.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SendSMSResultDTO"
+              }
+            ]
           }
         },
         "required": [
@@ -1604,7 +1655,12 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/RetrieveSMSDTO"
+            "description": "The message.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RetrieveSMSDTO"
+              }
+            ]
           }
         },
         "required": [
@@ -1718,7 +1774,12 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/SMSBatchResultDTO"
+            "description": "The batch and the messages in it.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SMSBatchResultDTO"
+              }
+            ]
           }
         },
         "required": [
@@ -1988,7 +2049,12 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/WebhookNotificationPageDTO"
+            "description": "Delivery records with pagination.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WebhookNotificationPageDTO"
+              }
+            ]
           }
         },
         "required": [
@@ -1999,7 +2065,12 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/WebhookSubscriptionDTO"
+            "description": "The subscription.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WebhookSubscriptionDTO"
+              }
+            ]
           }
         },
         "required": [
@@ -2106,7 +2177,12 @@
         "type": "object",
         "properties": {
           "data": {
-            "$ref": "#/components/schemas/WebhookDeletedResultDTO"
+            "description": "Outcome of the delete.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/WebhookDeletedResultDTO"
+              }
+            ]
           }
         },
         "required": [

--- a/api/package.json
+++ b/api/package.json
@@ -10,6 +10,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "export:openapi": "nest build && node dist/openapi/export-openapi.js",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start": "node dist/main.js",

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -15,21 +15,43 @@ import {
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiQuery,
+  ApiResponse,
   ApiSecurity,
   ApiTags,
 } from '@nestjs/swagger'
 import {
+  ApiKeyCreatedResponseDTO,
+  ApiKeyListResponseDTO,
+  AuthSessionResponseDTO,
+  ChangePasswordInputDTO,
+  GoogleLoginInputDTO,
   LoginInputDTO,
+  MessageResponseDTO,
   RegisterInputDTO,
+  RenameApiKeyInputDTO,
   RequestResetPasswordInputDTO,
   ResetPasswordInputDTO,
   UpdateOnboardingDTO,
+  UpdateProfileInputDTO,
+  UserResponseDTO,
+  VerifyEmailInputDTO,
 } from './auth.dto'
 import { AuthGuard } from './guards/auth.guard'
 import { AuthService } from './auth.service'
 import { UsersService } from '../users/users.service'
 import { CanModifyApiKey } from './guards/can-modify-api-key.guard'
+
+const API_KEY_ID_PARAM = {
+  name: 'id',
+  description: 'API key id, from GET /auth/api-keys.',
+} as const
+
+const UNAUTHORIZED_RESPONSE = {
+  status: 401,
+  description: 'Missing or invalid credentials.',
+} as const
 
 @ApiTags('auth')
 @Controller('auth')
@@ -39,7 +61,24 @@ export class AuthController {
     private usersService: UsersService,
   ) {}
 
-  @ApiOperation({ summary: 'Login' })
+  @ApiOperation({
+    summary: 'Sign in with email and password',
+    description:
+      'Returns a JWT for the dashboard. Programmatic callers use an API key instead and never need this endpoint.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Signed in.',
+    type: AuthSessionResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'The Turnstile check failed.',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Wrong email or password.',
+  })
   @HttpCode(HttpStatus.OK)
   @Post('/login')
   async login(@Body() input: LoginInputDTO) {
@@ -47,22 +86,59 @@ export class AuthController {
     return { data }
   }
 
-  @ApiOperation({ summary: 'Login With Google' })
+  @ApiOperation({
+    summary: 'Sign in with Google',
+    description:
+      'Exchanges a Google ID token for a textbee session. Creates the account on first sign in.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Signed in.',
+    type: AuthSessionResponseDTO,
+  })
+  @ApiResponse({
+    status: 401,
+    description:
+      'The Google token is invalid, was issued for another app, or its email is unverified.',
+  })
   @HttpCode(HttpStatus.OK)
   @Post('/google-login')
-  async googleLogin(@Body() input: any) {
+  async googleLogin(@Body() input: GoogleLoginInputDTO) {
     const data = await this.authService.loginWithGoogle(input.idToken)
     return { data }
   }
 
-  @ApiOperation({ summary: 'Register' })
+  @ApiOperation({
+    summary: 'Create an account',
+    description:
+      'Creates the account and signs it in. Verify the email before sending, since unverified accounts cannot send messages.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'The account was created.',
+    type: AuthSessionResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'The email is already in use, or the Turnstile check failed.',
+  })
   @Post('/register')
   async register(@Body() input: RegisterInputDTO) {
     const data = await this.authService.register(input)
     return { data }
   }
 
-  @ApiOperation({ summary: 'Get current logged in user' })
+  @ApiOperation({
+    summary: 'Get the current account',
+    description:
+      'The account behind the credentials on the request. Useful to check which account an API key belongs to.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The current account.',
+    type: UserResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
@@ -71,34 +147,63 @@ export class AuthController {
     return { data: req.user }
   }
 
-  @ApiOperation({ summary: 'Update Profile' })
+  @ApiOperation({
+    summary: 'Update your profile',
+    description: 'Changes the name and phone number on the account.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The updated account.',
+    type: UserResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
   @Patch('/update-profile')
   async updateProfile(
-    @Body() input: { name: string; phone: string },
+    @Body() input: UpdateProfileInputDTO,
     @Request() req,
   ) {
     return await this.authService.updateProfile(input, req.user)
   }
 
-  @ApiOperation({ summary: 'Change Password' })
+  @ApiOperation({
+    summary: 'Change your password',
+    description: 'Requires the current password.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The password was changed.',
+    type: MessageResponseDTO,
+  })
+  @ApiResponse({ status: 400, description: 'The current password is wrong.' })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
   @Post('/change-password')
   async changePassword(
-    @Body() input: { oldPassword: string; newPassword: string },
+    @Body() input: ChangePasswordInputDTO,
     @Request() req,
   ) {
     return await this.authService.changePassword(input, req.user)
   }
 
   @UseGuards(AuthGuard)
-  @ApiOperation({ summary: 'Generate Api Key' })
+  @ApiOperation({
+    summary: 'Create an API key',
+    description:
+      'Creates a key with full access to the account. The full key is returned once and only stored hashed, so copy it now.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'The new key, in full.',
+    type: ApiKeyCreatedResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @Post('/api-keys')
@@ -108,14 +213,24 @@ export class AuthController {
   }
 
   @UseGuards(AuthGuard)
-  @ApiOperation({ summary: 'Get Api Key List (masked***)' })
+  @ApiOperation({
+    summary: 'List your API keys',
+    description:
+      'Keys are returned masked, newest first. The full key is only ever shown when it is created.',
+  })
   @ApiQuery({
     name: 'status',
     required: false,
     enum: ['active', 'revoked', 'all'],
-    description:
-      'Filter keys: active (default), revoked only, or all (legacy full list)',
+    description: 'Which keys to return. Default active.',
   })
+  @ApiResponse({
+    status: 200,
+    description: 'Your keys, masked.',
+    type: ApiKeyListResponseDTO,
+  })
+  @ApiResponse({ status: 400, description: 'Unknown status value.' })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @Get('/api-keys')
@@ -128,7 +243,19 @@ export class AuthController {
   }
 
   @UseGuards(AuthGuard, CanModifyApiKey)
-  @ApiOperation({ summary: 'Delete Api Key' })
+  @ApiOperation({
+    summary: 'Delete an API key',
+    description:
+      'Removes the key and its usage record. Revoke instead if you want to keep the record.',
+  })
+  @ApiParam(API_KEY_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The key was deleted.',
+    type: MessageResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse({ status: 404, description: 'No such key on your account.' })
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @HttpCode(HttpStatus.OK)
@@ -139,7 +266,19 @@ export class AuthController {
   }
 
   @UseGuards(AuthGuard, CanModifyApiKey)
-  @ApiOperation({ summary: 'Revoke Api Key' })
+  @ApiOperation({
+    summary: 'Revoke an API key',
+    description:
+      'Stops the key working immediately while keeping it in the list. Use this when a key may have leaked.',
+  })
+  @ApiParam(API_KEY_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The key was revoked.',
+    type: MessageResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse({ status: 404, description: 'No such key on your account.' })
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @HttpCode(HttpStatus.OK)
@@ -150,17 +289,37 @@ export class AuthController {
   }
 
   @UseGuards(AuthGuard, CanModifyApiKey)
-  @ApiOperation({ summary: 'Rename Api Key' })
+  @ApiOperation({
+    summary: 'Rename an API key',
+    description: 'Changes the label only. The key itself is unchanged.',
+  })
+  @ApiParam(API_KEY_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The key was renamed.',
+    type: MessageResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse({ status: 404, description: 'No such key on your account.' })
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @HttpCode(HttpStatus.OK)
   @Patch('/api-keys/:id/rename')
-  async renameApiKey(@Param() params, @Body() input: { name: string }) {
+  async renameApiKey(@Param() params, @Body() input: RenameApiKeyInputDTO) {
     await this.authService.renameApiKey(params.id, input.name)
     return { message: 'API Key Renamed' }
   }
 
-  @ApiOperation({ summary: 'Update dashboard onboarding progress' })
+  @ApiOperation({
+    summary: 'Update dashboard onboarding progress',
+    description: 'Tracks which onboarding step the dashboard should show next.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The updated account.',
+    type: UserResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
@@ -173,14 +332,36 @@ export class AuthController {
     return { data: user }
   }
 
-  @ApiOperation({ summary: 'Request Password Reset' })
+  @ApiOperation({
+    summary: 'Request a password reset code',
+    description:
+      'Emails a one time code. The response is the same whether or not the address has an account.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The request was accepted.',
+    type: MessageResponseDTO,
+  })
+  @ApiResponse({ status: 400, description: 'The Turnstile check failed.' })
   @HttpCode(HttpStatus.OK)
   @Post('/request-password-reset')
   async requestPasswordReset(@Body() input: RequestResetPasswordInputDTO) {
     return await this.authService.requestResetPassword(input)
   }
 
-  @ApiOperation({ summary: 'Reset Password' })
+  @ApiOperation({
+    summary: 'Set a new password with a reset code',
+    description: 'Completes the reset started by the request endpoint.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The password was reset.',
+    type: MessageResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'The code is wrong or has expired.',
+  })
   @HttpCode(HttpStatus.OK)
   @Post('/reset-password')
   async resetPassword(@Body() input: ResetPasswordInputDTO) {
@@ -188,7 +369,17 @@ export class AuthController {
   }
 
   // send email verification code
-  @ApiOperation({ summary: 'Send Email Verification Code' })
+  @ApiOperation({
+    summary: 'Send an email verification code',
+    description:
+      'Emails a code to the current account. Sending messages is blocked until the email is verified.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The email was sent.',
+    type: MessageResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
@@ -198,11 +389,24 @@ export class AuthController {
     return await this.authService.sendEmailVerificationEmail(req.user)
   }
 
-  @ApiOperation({ summary: 'Verify Email' })
+  @ApiOperation({
+    summary: 'Verify an email address',
+    description: 'Confirms the code from the verification email.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The email is verified.',
+    type: MessageResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'The code is wrong or has expired.',
+  })
+  @ApiResponse({ status: 404, description: 'No such account.' })
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
   @Post('/verify-email')
-  async verifyEmail(@Body() input: { userId: string; verificationCode: string }) {
+  async verifyEmail(@Body() input: VerifyEmailInputDTO) {
     return await this.authService.verifyEmail(input)
   }
 }

--- a/api/src/auth/auth.dto.ts
+++ b/api/src/auth/auth.dto.ts
@@ -1,60 +1,302 @@
 import { ApiProperty } from '@nestjs/swagger'
 
 export class RegisterInputDTO {
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Full name shown in the dashboard.',
+    example: 'Ada Lovelace',
+  })
   name: string
 
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Email address. Must not already have an account.',
+    example: 'ada@example.com',
+  })
   email: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Phone number, for account recovery.',
+  })
   phone?: string
 
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Password for the new account.',
+  })
   password: string
 
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Cloudflare Turnstile token from the signup form.',
+  })
   turnstileToken: string
 }
 
 export class LoginInputDTO {
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Email address on the account.',
+    example: 'ada@example.com',
+  })
   email: string
 
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({ type: String, required: true, description: 'Password.' })
   password: string
 
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Cloudflare Turnstile token from the login form.',
+  })
   turnstileToken: string
 }
 
+export class GoogleLoginInputDTO {
+  @ApiProperty({
+    type: String,
+    required: true,
+    description:
+      'Google ID token from the browser sign-in flow. It must be issued for the textbee client and carry a verified email.',
+  })
+  idToken: string
+}
+
 export class RequestResetPasswordInputDTO {
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Email address to send the reset code to.',
+  })
   email: string
 
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Cloudflare Turnstile token from the form.',
+  })
   turnstileToken: string
 }
 
 export class ResetPasswordInputDTO {
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Email address on the account.',
+  })
   email: string
 
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'One time code from the reset email.',
+  })
   otp: string
 
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({ type: String, required: true, description: 'New password.' })
   newPassword: string
 }
 
+export class UpdateProfileInputDTO {
+  @ApiProperty({ type: String, required: false, description: 'New full name.' })
+  name: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'New phone number.',
+  })
+  phone: string
+}
+
+export class ChangePasswordInputDTO {
+  @ApiProperty({ type: String, required: true, description: 'Current password.' })
+  oldPassword: string
+
+  @ApiProperty({ type: String, required: true, description: 'New password.' })
+  newPassword: string
+}
+
+export class RenameApiKeyInputDTO {
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'New label for the key.',
+    example: 'n8n production',
+  })
+  name: string
+}
+
+export class VerifyEmailInputDTO {
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Id of the account to verify.',
+  })
+  userId: string
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Code from the verification email.',
+  })
+  verificationCode: string
+}
+
 export class UpdateOnboardingDTO {
-  @ApiProperty({ required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Step the user is on now.',
+  })
   currentStepId?: string
 
-  @ApiProperty({ required: false, description: 'Only allowed for optional steps' })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Step to skip. Only allowed for optional steps.',
+  })
   skipStepId?: string
 
-  @ApiProperty({ required: false, description: 'When true, sets onboarding.completedAt' })
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description: 'When true, marks onboarding finished.',
+  })
   complete?: boolean
 }
 
+export class UserDTO {
+  @ApiProperty({ type: String, description: 'Account id.' })
+  _id: string
+
+  @ApiProperty({ type: String, required: false, description: 'Full name.' })
+  name?: string
+
+  @ApiProperty({ type: String, description: 'Email address.' })
+  email: string
+
+  @ApiProperty({ type: String, required: false, description: 'Phone number.' })
+  phone?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Avatar URL, set when the account signed up with Google.',
+  })
+  avatar?: string
+
+  @ApiProperty({ type: String, description: 'Account role.' })
+  role: string
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description:
+      'When the email was verified. Sending is blocked until this is set.',
+  })
+  emailVerifiedAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'Last successful login.',
+  })
+  lastLoginAt?: Date
+
+  @ApiProperty({ type: Date, description: 'When the account was created.' })
+  createdAt: Date
+}
+
+export class AuthSessionDTO {
+  @ApiProperty({
+    type: String,
+    description:
+      'JWT for the dashboard, sent as an Authorization bearer token. API requests use an API key instead.',
+  })
+  accessToken: string
+
+  @ApiProperty({ type: UserDTO, description: 'The signed in account.' })
+  user: UserDTO
+}
+
+export class AuthSessionResponseDTO {
+  @ApiProperty({ type: AuthSessionDTO })
+  data: AuthSessionDTO
+}
+
+export class UserResponseDTO {
+  @ApiProperty({ type: UserDTO })
+  data: UserDTO
+}
+
+export class MessageResponseDTO {
+  @ApiProperty({
+    type: String,
+    description: 'What happened, in plain words.',
+    example: 'Password reset successfully',
+  })
+  message: string
+}
+
+export class ApiKeyDTO {
+  @ApiProperty({ type: String, description: 'Key id.' })
+  _id: string
+
+  @ApiProperty({
+    type: String,
+    description: 'Masked key. Only the first characters are stored.',
+    example: '2a1b3c4d5e6f7g8h9******************',
+  })
+  apiKey: string
+
+  @ApiProperty({ type: String, description: 'Label for the key.' })
+  name: string
+
+  @ApiProperty({ type: Number, description: 'Requests made with this key.' })
+  usageCount: number
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'Last time the key was used.',
+  })
+  lastUsedAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When the key was revoked. Absent while the key is active.',
+  })
+  revokedAt?: Date
+
+  @ApiProperty({ type: Date, description: 'When the key was created.' })
+  createdAt: Date
+}
+
+export class ApiKeyListResponseDTO {
+  @ApiProperty({ type: [ApiKeyDTO] })
+  data: ApiKeyDTO[]
+}
+
+export class ApiKeyCreatedResponseDTO {
+  @ApiProperty({
+    type: String,
+    description:
+      'The full API key. This is the only time it is returned, so store it now.',
+  })
+  data: string
+
+  @ApiProperty({
+    type: String,
+    description: 'Reminder that the key will not be shown again.',
+  })
+  message: string
+}

--- a/api/src/auth/auth.dto.ts
+++ b/api/src/auth/auth.dto.ts
@@ -228,12 +228,12 @@ export class AuthSessionDTO {
 }
 
 export class AuthSessionResponseDTO {
-  @ApiProperty({ type: AuthSessionDTO })
+  @ApiProperty({ type: AuthSessionDTO, description: 'Token and account.' })
   data: AuthSessionDTO
 }
 
 export class UserResponseDTO {
-  @ApiProperty({ type: UserDTO })
+  @ApiProperty({ type: UserDTO, description: 'The account.' })
   data: UserDTO
 }
 
@@ -282,7 +282,7 @@ export class ApiKeyDTO {
 }
 
 export class ApiKeyListResponseDTO {
-  @ApiProperty({ type: [ApiKeyDTO] })
+  @ApiProperty({ type: [ApiKeyDTO], description: 'Your keys, masked.' })
   data: ApiKeyDTO[]
 }
 

--- a/api/src/billing/billing.controller.ts
+++ b/api/src/billing/billing.controller.ts
@@ -1,15 +1,30 @@
 import { Controller, Post, Body, Get, UseGuards, Request } from '@nestjs/common'
 import { BillingService } from './billing.service'
 import { AuthGuard } from 'src/auth/guards/auth.guard'
-import { ApiTags, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger'
 import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiExcludeEndpoint,
+  ApiOperation,
+  ApiResponse,
+  ApiSecurity,
+} from '@nestjs/swagger'
+import {
+  BillingNotificationDTO,
   ChangePlanInputDTO,
   ChangePlanResponseDTO,
   CheckoutInputDTO,
   CheckoutResponseDTO,
+  CurrentSubscriptionResponseDTO,
+  PlanDTO,
   PlansResponseDTO,
 } from './billing.dto'
 import { BillingNotificationsService } from './billing-notifications.service'
+
+const UNAUTHORIZED_RESPONSE = {
+  status: 401,
+  description: 'Missing, invalid, or revoked API key.',
+} as const
 
 @ApiTags('billing')
 @Controller('billing')
@@ -19,11 +34,31 @@ export class BillingController {
     private billingNotifications: BillingNotificationsService,
   ) {}
 
+  @ApiOperation({
+    summary: 'List the available plans',
+    description: 'Public plan catalogue with prices. No credentials needed.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Plans that can be subscribed to.',
+    type: [PlanDTO],
+  })
   @Get('plans')
   async getPlans(): Promise<PlansResponseDTO> {
     return this.billingService.getPlans()
   }
 
+  @ApiOperation({
+    summary: 'Get your plan and usage',
+    description:
+      'The plan in force plus how much of its limits the account has used. Accounts without a paid plan get the free one.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Current plan and usage.',
+    type: CurrentSubscriptionResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @Get('current-subscription')
   @UseGuards(AuthGuard)
   @ApiBearerAuth()
@@ -32,6 +67,17 @@ export class BillingController {
     return this.billingService.getCurrentSubscription(req.user)
   }
 
+  @ApiOperation({
+    summary: 'List billing notifications',
+    description:
+      'Alerts raised for the account, newest first, such as a limit being reached or an email needing verification.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Up to 50 notifications.',
+    type: [BillingNotificationDTO],
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @Get('notifications')
   @UseGuards(AuthGuard)
   @ApiBearerAuth()
@@ -40,6 +86,21 @@ export class BillingController {
     return this.billingNotifications.listForUser(req.user._id)
   }
 
+  @ApiOperation({
+    summary: 'Start a checkout',
+    description:
+      'Returns a Polar checkout URL for the chosen plan. An account that already pays gets a plan change preview instead, which you confirm through POST /billing/change-plan.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'A checkout URL, or a plan change to confirm.',
+    type: CheckoutResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Unknown plan, or the plan cannot be subscribed to.',
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @Post('checkout')
   @UseGuards(AuthGuard)
   @ApiBearerAuth()
@@ -55,6 +116,21 @@ export class BillingController {
     })
   }
 
+  @ApiOperation({
+    summary: 'Switch to another plan',
+    description:
+      'Applies a plan change for an account that already has a paid subscription. Polar handles the proration.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'The plan was switched.',
+    type: ChangePlanResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Unknown plan, or there is no subscription to change.',
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @Post('change-plan')
   @UseGuards(AuthGuard)
   @ApiBearerAuth()
@@ -69,6 +145,9 @@ export class BillingController {
     })
   }
 
+  // Provider to server callback with a signed raw body, not something a
+  // developer calls, so it stays out of the docs.
+  @ApiExcludeEndpoint()
   @Post('webhook/polar')
   async handlePolarWebhook(@Body() data: any, @Request() req: any) {
     const payload = await this.billingService.validatePolarWebhookPayload(

--- a/api/src/billing/billing.dto.ts
+++ b/api/src/billing/billing.dto.ts
@@ -1,83 +1,294 @@
 import { ApiProperty } from '@nestjs/swagger'
 
 export class PlanDTO {
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    description: 'Plan identifier, used as planName when starting a checkout.',
+    example: 'pro',
+  })
   name: string
 
-  @ApiProperty({ type: Number })
+  @ApiProperty({
+    type: Number,
+    description: 'Monthly price in the plan currency.',
+  })
   monthlyPrice: number
 
-  @ApiProperty({ type: Number })
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Yearly price, when the plan can be billed yearly.',
+  })
   yearlyPrice?: number
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Polar product backing this plan.',
+  })
   polarProductId?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Polar product for monthly billing.',
+  })
   polarMonthlyProductId?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Polar product for yearly billing.',
+  })
   polarYearlyProductId?: string
 
-  @ApiProperty({ type: Boolean })
+  @ApiProperty({
+    type: Boolean,
+    description: 'Whether the plan can be subscribed to right now.',
+  })
   isActive: boolean
 }
 
 export class PlansResponseDTO extends Array<PlanDTO> {}
 
 export class CheckoutInputDTO {
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Plan to subscribe to, by name.',
+    example: 'pro',
+  })
   planName: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Polar discount to apply at checkout.',
+  })
   discountId?: string
 
-  @ApiProperty({ enum: ['monthly', 'yearly'], required: false })
+  @ApiProperty({
+    enum: ['monthly', 'yearly'],
+    required: false,
+    description: 'Billing period. Defaults to monthly.',
+  })
   billingInterval?: 'monthly' | 'yearly'
 }
 
 export class PlanChangePreviewDTO {
-  @ApiProperty({ type: String })
+  @ApiProperty({ type: String, description: 'Plan the account is on now.' })
   currentPlan: string
 
-  @ApiProperty({ enum: ['monthly', 'yearly'] })
+  @ApiProperty({
+    enum: ['monthly', 'yearly'],
+    description: 'Billing period in force now.',
+  })
   currentInterval: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({ type: String, description: 'Plan being moved to.' })
   newPlan: string
 
-  @ApiProperty({ enum: ['monthly', 'yearly'] })
+  @ApiProperty({
+    enum: ['monthly', 'yearly'],
+    description: 'Billing period being moved to.',
+  })
   newInterval: string
 
-  @ApiProperty({ type: Boolean })
+  @ApiProperty({
+    type: Boolean,
+    description: 'Whether the change raises the plan level.',
+  })
   isUpgrade: boolean
 
-  @ApiProperty({ type: Boolean })
+  @ApiProperty({
+    type: Boolean,
+    description: 'Whether the current subscription ends at the period end.',
+  })
   cancelAtPeriodEnd: boolean
 }
 
 export class CheckoutResponseDTO {
-  @ApiProperty({ type: String, required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Polar checkout URL to send the user to.',
+  })
   redirectUrl?: string
 
   // returned instead of redirectUrl when the user already has an active paid
   // Polar subscription, so the frontend shows a confirmation screen
-  @ApiProperty({ type: PlanChangePreviewDTO, required: false })
+  @ApiProperty({
+    type: PlanChangePreviewDTO,
+    required: false,
+    description:
+      'Returned instead of redirectUrl when the account already pays for a plan. Confirm it, then call POST /billing/change-plan.',
+  })
   planChange?: PlanChangePreviewDTO
 }
 
 export class ChangePlanInputDTO {
-  @ApiProperty({ type: String, required: true })
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Plan to switch to, by name.',
+    example: 'pro',
+  })
   planName: string
 
-  @ApiProperty({ enum: ['monthly', 'yearly'], required: false })
+  @ApiProperty({
+    enum: ['monthly', 'yearly'],
+    required: false,
+    description: 'Billing period to switch to.',
+  })
   billingInterval?: 'monthly' | 'yearly'
 }
 
 export class ChangePlanResponseDTO {
-  @ApiProperty({ type: Boolean })
+  @ApiProperty({ type: Boolean, description: 'Whether the switch succeeded.' })
   success: boolean
 
-  @ApiProperty({ type: String })
+  @ApiProperty({ type: String, description: 'Plan the account is now on.' })
   plan: string
+}
+
+export class SubscriptionUsageDTO {
+  @ApiProperty({ type: Number, description: 'Messages processed today.' })
+  processedSmsToday: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Messages processed in the last month.',
+  })
+  processedSmsLastMonth: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Messages allowed per day. -1 means unlimited.',
+  })
+  dailyLimit: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Messages allowed per month. -1 means unlimited.',
+  })
+  monthlyLimit: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Messages allowed in one bulk send. -1 means unlimited.',
+  })
+  bulkSendLimit: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Devices allowed on the account. -1 means unlimited.',
+  })
+  deviceLimit: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Messages left today. -1 when the daily limit is unlimited.',
+  })
+  dailyRemaining: number
+
+  @ApiProperty({
+    type: Number,
+    description:
+      'Messages left this month. -1 when the monthly limit is unlimited.',
+  })
+  monthlyRemaining: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Share of the daily allowance used, 0 to 100.',
+  })
+  dailyUsagePercentage: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Share of the monthly allowance used, 0 to 100.',
+  })
+  monthlyUsagePercentage: number
+}
+
+export class CurrentSubscriptionResponseDTO {
+  @ApiProperty({
+    type: PlanDTO,
+    description: 'Plan in force. Accounts without a paid plan get the free one.',
+  })
+  plan: PlanDTO
+
+  @ApiProperty({
+    type: Boolean,
+    description: 'Whether the subscription is currently active.',
+  })
+  isActive: boolean
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Subscription state reported by Polar.',
+  })
+  status?: string
+
+  @ApiProperty({
+    enum: ['monthly', 'yearly'],
+    required: false,
+    description: 'Billing period. Absent on the free plan.',
+  })
+  recurringInterval?: string
+
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description: 'Whether the plan ends when the paid period does.',
+  })
+  cancelAtPeriodEnd?: boolean
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'Start of the paid period.',
+  })
+  currentPeriodStart?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'End of the paid period.',
+  })
+  currentPeriodEnd?: Date
+
+  @ApiProperty({
+    type: SubscriptionUsageDTO,
+    description: 'Limits and how much of them the account has used.',
+  })
+  usage: SubscriptionUsageDTO
+}
+
+export class BillingNotificationDTO {
+  @ApiProperty({ type: String, description: 'Notification id.' })
+  _id: string
+
+  @ApiProperty({
+    type: String,
+    description: 'What triggered it, for example a limit being reached.',
+  })
+  type: string
+
+  @ApiProperty({ type: String, description: 'Headline shown in the dashboard.' })
+  title: string
+
+  @ApiProperty({ type: String, description: 'Body text.' })
+  message: string
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When the account read it. Absent while unread.',
+  })
+  readAt?: Date
+
+  @ApiProperty({ type: Date, description: 'When it was raised.' })
+  createdAt: Date
 }

--- a/api/src/gateway/gateway.controller.ts
+++ b/api/src/gateway/gateway.controller.ts
@@ -14,6 +14,7 @@ import {
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiResponse,
   ApiSecurity,
@@ -21,6 +22,9 @@ import {
 } from '@nestjs/swagger'
 import { AuthGuard } from '../auth/guards/auth.guard'
 import {
+  DeviceListResponseDTO,
+  DeviceResponseDTO,
+  GatewayStatsResponseDTO,
   ReceivedSMSDTO,
   RegisterDeviceInputDTO,
   pickDeviceWritableFields,
@@ -29,12 +33,36 @@ import {
   SendBulkSMSRequestDTO,
   SendSMSInputDTO,
   SendSMSRequestDTO,
+  SendSMSResponseDTO,
+  SMSBatchResponseDTO,
+  SMSResponseDTO,
+  SuccessResponseDTO,
   UpdateSMSStatusDTO,
   HeartbeatInputDTO,
   HeartbeatResponseDTO,
 } from './gateway.dto'
 import { GatewayService } from './gateway.service'
 import { CanModifyDevice } from './guards/can-modify-device.guard'
+
+const DEVICE_ID_PARAM = {
+  name: 'id',
+  description: 'Device id, from GET /gateway/devices.',
+} as const
+
+const UNAUTHORIZED_RESPONSE = {
+  status: 401,
+  description: 'Missing, invalid, or revoked API key.',
+} as const
+
+const DEVICE_NOT_FOUND_RESPONSE = {
+  status: 404,
+  description: 'No device with that id on your account.',
+} as const
+
+const INVALID_DEVICE_ID_RESPONSE = {
+  status: 400,
+  description: 'The device id is not a valid id.',
+} as const
 
 // Query params arrive as strings; non-integer or out-of-range values resolve
 // to the defaults (page 1, limit 50) and limit is capped at 100.
@@ -58,6 +86,17 @@ export class GatewayController {
   constructor(private readonly gatewayService: GatewayService) {}
 
   @UseGuards(AuthGuard)
+  @ApiOperation({
+    summary: 'Get account totals',
+    description:
+      'Messages sent, messages received, devices, and API keys across your whole account.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Account totals.',
+    type: GatewayStatsResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @Get('/stats')
   async getStats(@Request() req) {
     const data = await this.gatewayService.getStatsForUser(req.user)
@@ -65,7 +104,17 @@ export class GatewayController {
   }
 
   @UseGuards(AuthGuard)
-  @ApiOperation({ summary: 'Register device' })
+  @ApiOperation({
+    summary: 'Register a device',
+    description:
+      'Pairs an Android phone with your account. The textbee app calls this on setup and again whenever the push token changes.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'The registered device.',
+    type: DeviceResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @Post('/devices')
   async registerDevice(@Body() input: RegisterDeviceInputDTO, @Request() req) {
     const data = await this.gatewayService.registerDevice(
@@ -76,14 +125,37 @@ export class GatewayController {
   }
 
   @UseGuards(AuthGuard)
-  @ApiOperation({ summary: 'List of registered devices' })
+  @ApiOperation({
+    summary: 'List your devices',
+    description:
+      'Every phone paired with your account. The push token and hardware serial are never returned.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Your devices.',
+    type: DeviceListResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @Get('/devices')
   async getDevices(@Request() req) {
     const data = await this.gatewayService.getDevicesForUser(req.user)
     return { data }
   }
 
-  @ApiOperation({ summary: 'Get device by id' })
+  @ApiOperation({
+    summary: 'Get a device',
+    description:
+      'Full state of one device, including its last heartbeat, battery, and SIM list.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The device.',
+    type: DeviceResponseDTO,
+  })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
   @UseGuards(AuthGuard, CanModifyDevice)
   @Get('/devices/:id')
   async getDevice(@Param('id') deviceId: string) {
@@ -95,7 +167,20 @@ export class GatewayController {
     return { data }
   }
 
-  @ApiOperation({ summary: 'Update device' })
+  @ApiOperation({
+    summary: 'Update a device',
+    description:
+      'Changes device settings such as the name or whether it is enabled. Only writable device fields are applied.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The updated device.',
+    type: DeviceResponseDTO,
+  })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
   @UseGuards(AuthGuard, CanModifyDevice)
   @Patch('/devices/:id')
   async updateDevice(
@@ -109,7 +194,20 @@ export class GatewayController {
     return { data }
   }
 
-  @ApiOperation({ summary: 'Device heartbeat' })
+  @ApiOperation({
+    summary: 'Report a device heartbeat',
+    description:
+      'Called by the textbee app on a schedule to report that the phone is online, refresh its push token, and upload battery, storage, and SIM state.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'Heartbeat accepted.',
+    type: HeartbeatResponseDTO,
+  })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
   @UseGuards(AuthGuard, CanModifyDevice)
   @Post('/devices/:id/heartbeat')
   @HttpCode(HttpStatus.OK)
@@ -121,7 +219,20 @@ export class GatewayController {
     return data
   }
 
-  @ApiOperation({ summary: 'Delete device' })
+  @ApiOperation({
+    summary: 'Delete a device',
+    description:
+      'Unpairs the phone. Message history is kept, and the app has to pair again to send from this phone.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The device was deleted.',
+    type: SuccessResponseDTO,
+  })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
   @UseGuards(AuthGuard, CanModifyDevice)
   @Delete('/devices/:id')
   async deleteDevice(@Param('id') deviceId: string) {
@@ -129,7 +240,20 @@ export class GatewayController {
     return { data }
   }
 
-  @ApiOperation({ summary: 'Set device as the default sender' })
+  @ApiOperation({
+    summary: 'Set the default sending device',
+    description:
+      'Sends that omit deviceId go out from this device. Any other device loses the flag.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The device is now the default.',
+    type: DeviceResponseDTO,
+  })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
   @UseGuards(AuthGuard, CanModifyDevice)
   @Post('/devices/:id/set-default')
   @HttpCode(HttpStatus.OK)
@@ -139,8 +263,26 @@ export class GatewayController {
   }
 
   @ApiOperation({
-    summary:
-      'Send SMS. deviceId is optional: defaults to your default device, else the most recently active enabled device.',
+    summary: 'Send an SMS',
+    description:
+      'Sends one message to one or more recipients from a phone on your account. deviceId is optional: without it textbee uses your default device, otherwise the enabled device with the most recent heartbeat. Every recipient counts as one message against your plan.',
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      'The send was accepted. Use smsBatchId to follow delivery. Acceptance is not delivery: the phone still has to be online.',
+    type: SendSMSResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'No enabled device to send from, the device is disabled, your email is not verified, or the message could not be pushed to the phone.',
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse({
+    status: 429,
+    description:
+      'Your daily, monthly, or per-batch plan limit is used up. The body says which one.',
   })
   @UseGuards(AuthGuard)
   @Post('/send-sms')
@@ -155,8 +297,25 @@ export class GatewayController {
   }
 
   @ApiOperation({
-    summary:
-      'Send Bulk SMS. deviceId is optional: defaults to your default device, else the most recently active enabled device.',
+    summary: 'Send several SMS in one call',
+    description:
+      'Sends a batch where every entry has its own text and recipients. deviceId is optional and resolves the same way as POST /gateway/send-sms.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The batch was accepted.',
+    type: SendSMSResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'No enabled device to send from, the device is disabled, your email is not verified, or the batch could not be pushed to the phone.',
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse({
+    status: 429,
+    description:
+      'Your daily, monthly, or per-batch plan limit is used up. The body says which one.',
   })
   @UseGuards(AuthGuard)
   @Post('/send-bulk-sms')
@@ -177,9 +336,16 @@ export class GatewayController {
   }
 
   @ApiOperation({
-    summary:
-      'Deprecated: use POST /gateway/send-sms with an optional deviceId in the body. Send SMS to a device.',
+    summary: 'Send an SMS from a named device',
+    description:
+      'Use POST /gateway/send-sms with an optional deviceId in the body instead. Kept so existing integrations keep working.',
     deprecated: true,
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 201,
+    description: 'The send was accepted.',
+    type: SendSMSResponseDTO,
   })
   @UseGuards(AuthGuard, CanModifyDevice)
   // deprecate sendSMS route in favor of send-sms, but allow both to prevent breaking changes
@@ -193,9 +359,16 @@ export class GatewayController {
   }
 
   @ApiOperation({
-    summary:
-      'Deprecated: use POST /gateway/send-bulk-sms with an optional deviceId in the body. Send Bulk SMS.',
+    summary: 'Send several SMS from a named device',
+    description:
+      'Use POST /gateway/send-bulk-sms with an optional deviceId in the body instead. Kept so existing integrations keep working.',
     deprecated: true,
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 201,
+    description: 'The batch was accepted.',
+    type: SendSMSResponseDTO,
   })
   @UseGuards(AuthGuard, CanModifyDevice)
   @Post(['/devices/:id/send-bulk-sms'])
@@ -208,7 +381,16 @@ export class GatewayController {
   }
 
 
-  @ApiOperation({ summary: 'Received SMS from a device' })
+  @ApiOperation({
+    summary: 'Report an incoming SMS',
+    description:
+      'Called by the textbee app when the phone receives a message. This is how received message history and MESSAGE_RECEIVED webhooks get their data.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({ status: 200, description: 'The message was stored.' })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
   @HttpCode(HttpStatus.OK)
   @Post('/devices/:id/receive-sms')
   @UseGuards(AuthGuard, CanModifyDevice)
@@ -218,10 +400,13 @@ export class GatewayController {
   }
 
   @ApiOperation({
-    summary:
-      'Deprecated: use POST /gateway/devices/{id}/receive-sms. Received SMS from a device.',
+    summary: 'Report an incoming SMS, legacy path',
+    description:
+      'Use POST /gateway/devices/{id}/receive-sms instead. Kept for older builds of the Android app.',
     deprecated: true,
   })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({ status: 200, description: 'The message was stored.' })
   @HttpCode(HttpStatus.OK)
   // legacy alias kept for older app versions and integrations
   @Post('/devices/:id/receiveSMS')
@@ -233,10 +418,32 @@ export class GatewayController {
     return await this.receiveSMS(deviceId, dto)
   }
 
-  @ApiOperation({ summary: 'Get received SMS from a device' })
-  @ApiResponse({ status: 200, type: RetrieveSMSResponseDTO })
-  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (default: 1)' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Number of items per page (default: 50, max: 100)' })
+  @ApiOperation({
+    summary: 'List received messages',
+    description:
+      'Messages this device received, newest first. Prefer GET /gateway/devices/{id}/messages, which covers both directions.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'A page of received messages.',
+    type: RetrieveSMSResponseDTO,
+  })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page to return. Default 1.',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Messages per page. Default 50, maximum 100.',
+  })
   @UseGuards(AuthGuard, CanModifyDevice)
   @Get('/devices/:id/get-received-sms')
   async getReceivedSMS(
@@ -252,13 +459,29 @@ export class GatewayController {
   }
 
   @ApiOperation({
-    summary:
-      'Deprecated: use GET /gateway/devices/{id}/get-received-sms. Get received SMS from a device.',
+    summary: 'List received messages, legacy path',
+    description:
+      'Use GET /gateway/devices/{id}/messages instead, or GET /gateway/devices/{id}/get-received-sms. Kept so existing integrations keep working.',
     deprecated: true,
   })
-  @ApiResponse({ status: 200, type: RetrieveSMSResponseDTO })
-  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (default: 1)' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Number of items per page (default: 50, max: 100)' })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'A page of received messages.',
+    type: RetrieveSMSResponseDTO,
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page to return. Default 1.',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Messages per page. Default 50, maximum 100.',
+  })
   @UseGuards(AuthGuard, CanModifyDevice)
   // legacy alias kept for older app versions and integrations
   @Get('/devices/:id/getReceivedSMS')
@@ -269,11 +492,46 @@ export class GatewayController {
     return await this.getReceivedSMS(deviceId, req)
   }
 
-  @ApiOperation({ summary: 'Get message history (sent and received) from a device' })
-  @ApiResponse({ status: 200, type: RetrieveSMSResponseDTO })
-  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (default: 1)' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Number of items per page (default: 50, max: 100)' })
-  @ApiQuery({ name: 'type', required: false, type: String, description: 'Filter by message type: all, sent, or received (default: all)' })
+  @ApiOperation({
+    summary: 'List message history',
+    description:
+      'Sent and received messages for one device, newest first, with delivery status on each. This is the endpoint to poll for new messages.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'A page of messages.',
+    type: RetrieveSMSResponseDTO,
+  })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page to return. Default 1.',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Messages per page. Default 50, maximum 100.',
+  })
+  @ApiQuery({
+    name: 'type',
+    required: false,
+    type: String,
+    enum: ['all', 'sent', 'received'],
+    description: 'Direction to return. Default all.',
+  })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    type: String,
+    description:
+      'Match against the message text and the other party number. Encrypted messages cannot be searched.',
+  })
   @UseGuards(AuthGuard, CanModifyDevice)
   @Get('/devices/:id/messages')
   async getMessages(
@@ -288,7 +546,16 @@ export class GatewayController {
     return result;
   }
 
-  @ApiOperation({ summary: 'Update SMS status' })
+  @ApiOperation({
+    summary: 'Update the delivery status of an SMS',
+    description:
+      'Called by the textbee app once the carrier reports the outcome. This is what moves a message from sent to delivered or failed.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiResponse({ status: 200, description: 'The status was recorded.' })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
   @UseGuards(AuthGuard, CanModifyDevice)
   @HttpCode(HttpStatus.OK)
   @Patch('/devices/:id/sms-status')
@@ -300,7 +567,27 @@ export class GatewayController {
     return { data };
   }
 
-  @ApiOperation({ summary: 'Get a single SMS by ID' })
+  @ApiOperation({
+    summary: 'Get one message',
+    description:
+      'A single sent or received message with its delivery timestamps. Use it to check the outcome of one recipient.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiParam({
+    name: 'smsId',
+    description: 'Message id, from the message history response.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The message.',
+    type: SMSResponseDTO,
+  })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse({
+    status: 404,
+    description: 'No such message on this device.',
+  })
   @UseGuards(AuthGuard, CanModifyDevice)
   @Get('/devices/:id/sms/:smsId')
   async getSMSById(
@@ -311,7 +598,27 @@ export class GatewayController {
     return { data };
   }
 
-  @ApiOperation({ summary: 'Get an SMS batch by ID with all its SMS messages' })
+  @ApiOperation({
+    summary: 'Get a send batch',
+    description:
+      'The batch returned by a send, plus one message per recipient. Poll this to see how a send is progressing.',
+  })
+  @ApiParam(DEVICE_ID_PARAM)
+  @ApiParam({
+    name: 'smsBatchId',
+    description: 'Batch id, returned as smsBatchId by the send endpoints.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The batch and its messages.',
+    type: SMSBatchResponseDTO,
+  })
+  @ApiResponse(INVALID_DEVICE_ID_RESPONSE)
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse({
+    status: 404,
+    description: 'No such batch on this device.',
+  })
   @UseGuards(AuthGuard, CanModifyDevice)
   @Get('/devices/:id/sms-batch/:smsBatchId')
   async getSmsBatchById(

--- a/api/src/gateway/gateway.dto.ts
+++ b/api/src/gateway/gateway.dto.ts
@@ -1,89 +1,217 @@
 import { ApiProperty } from '@nestjs/swagger'
 
 export class SimInfoDTO {
-  @ApiProperty({ type: Number, required: true })
+  @ApiProperty({
+    type: Number,
+    required: true,
+    description:
+      'Android subscription id of the SIM. Pass it as simSubscriptionId when sending to choose this SIM.',
+    example: 1,
+  })
   subscriptionId: number
 
-  @ApiProperty({ type: String, required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'ICCID of the SIM card.',
+  })
   iccId?: string
 
-  @ApiProperty({ type: Number, required: false })
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Android card id of the SIM slot.',
+  })
   cardId?: number
 
-  @ApiProperty({ type: String, required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Mobile network operator, as reported by Android.',
+    example: 'Safaricom',
+  })
   carrierName?: string
 
-  @ApiProperty({ type: String, required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Label the user gave this SIM on the device.',
+  })
   displayName?: string
 
-  @ApiProperty({ type: Number, required: false })
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Physical SIM slot, starting at 0.',
+    example: 0,
+  })
   simSlotIndex?: number
 
-  @ApiProperty({ type: String, required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Mobile country code.',
+    example: '639',
+  })
   mcc?: string
 
-  @ApiProperty({ type: String, required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Mobile network code.',
+    example: '02',
+  })
   mnc?: string
 
-  @ApiProperty({ type: String, required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Two letter country code of the SIM.',
+    example: 'ke',
+  })
   countryIso?: string
 
-  @ApiProperty({ type: String, required: false, enum: ['PHYSICAL_SIM', 'ESIM'] })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Whether the SIM is physical or an eSIM.',
+    enum: ['PHYSICAL_SIM', 'ESIM'],
+  })
   subscriptionType?: string
 }
 
 export class SimInfoCollectionDTO {
-  @ApiProperty({ type: Date, required: true })
+  @ApiProperty({
+    type: Date,
+    required: true,
+    description: 'When the device last reported its SIM list.',
+  })
   lastUpdated: Date
 
-  @ApiProperty({ type: [SimInfoDTO], required: true })
+  @ApiProperty({
+    type: [SimInfoDTO],
+    required: true,
+    description: 'SIMs currently installed in the device.',
+  })
   sims: SimInfoDTO[]
 }
 
 export class RegisterDeviceInputDTO {
-  @ApiProperty({ type: Boolean })
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description: 'Whether the device may send and receive SMS.',
+  })
   enabled?: boolean
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      'Firebase Cloud Messaging token. textbee pushes send jobs to this token, so a stale value stops delivery.',
+  })
   fcmToken?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Device brand.',
+    example: 'google',
+  })
   brand?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Device manufacturer.',
+    example: 'Google',
+  })
   manufacturer?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Device model.',
+    example: 'Pixel 7',
+  })
   model?: string
 
-  @ApiProperty({ type: String, required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Your own label for the device, shown in the dashboard.',
+    example: 'Office phone',
+  })
   name?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Hardware serial. Stored, but never returned by the API.',
+  })
   serial?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Android build id.',
+    example: 'TQ3A.230805.001',
+  })
   buildId?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Operating system name.',
+    example: 'Android',
+  })
   os?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Android release version.',
+    example: '16',
+  })
   osVersion?: string
 
-  @ApiProperty({ type: Number, required: false })
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Android SDK level.',
+    example: 36,
+  })
   osApiLevel?: number
 
-  @ApiProperty({ type: String, required: false })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      'Android build fingerprint. Used to fill in the release version when the device does not report one.',
+  })
   osBuildFingerprint?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'textbee app version name.',
+    example: '1.9.0',
+  })
   appVersionName?: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'textbee app version code.',
+    example: 190,
+  })
   appVersionCode?: number
 
-  @ApiProperty({ type: SimInfoCollectionDTO, required: false })
+  @ApiProperty({
+    type: SimInfoCollectionDTO,
+    required: false,
+    description: 'SIMs installed in the device.',
+  })
   simInfo?: SimInfoCollectionDTO
 }
 
@@ -128,14 +256,16 @@ export class SMSData {
   @ApiProperty({
     type: String,
     required: true,
-    description: 'The message to send',
+    description: 'Text of the message. Long messages are split by the carrier.',
+    example: 'Your appointment is confirmed for Tuesday at 10am.',
   })
   message: string
 
   @ApiProperty({
-    type: Array,
+    type: [String],
     required: true,
-    description: 'List of phone numbers to send the SMS to',
+    description:
+      'Phone numbers to send to, in international format. Each recipient is billed as one message.',
     example: ['+2519xxxxxxxx', '+2517xxxxxxxx'],
   })
   recipients: string[]
@@ -143,14 +273,17 @@ export class SMSData {
   @ApiProperty({
     type: Number,
     required: false,
-    description: 'Optional SIM subscription ID to use for sending SMS',
+    description:
+      'SIM to send from, as subscriptionId from the device simInfo. Defaults to the device default SIM.',
+    example: 1,
   })
   simSubscriptionId?: number
 
   @ApiProperty({
     type: String,
     required: false,
-    description: 'Optional ISO 8601 date string to schedule SMS for future delivery (e.g., "2024-01-15T10:30:00Z"). Must be a future date.',
+    description:
+      'ISO 8601 time to send the message. Must be in the future. Omit to send now.',
     example: '2024-01-15T10:30:00Z',
   })
   scheduledAt?: string
@@ -163,21 +296,22 @@ export class SMSData {
   //   recipient: string
   // }
 
-  // Legacy fields to be removed in the future
-  // @ApiProperty({
-  //   type: String,
-  //   required: true,
-  //   description: '(Legacy) Will be Replace with `message` field in the future',
-  // })
+  @ApiProperty({
+    type: String,
+    required: false,
+    deprecated: true,
+    description: 'Legacy alias for message. Used only when message is absent.',
+  })
   smsBody: string
 
-  // @ApiProperty({
-  //   type: Array,
-  //   required: false,
-  //   description:
-  //     '(Legacy) Will be Replace with `recipients` field in the future',
-  //   example: ['+2519xxxxxxxx', '+2517xxxxxxxx'],
-  // })
+  @ApiProperty({
+    type: [String],
+    required: false,
+    deprecated: true,
+    description:
+      'Legacy alias for recipients. Used only when recipients is absent.',
+    example: ['+2519xxxxxxxx', '+2517xxxxxxxx'],
+  })
   receivers: string[]
 }
 export class SendSMSInputDTO extends SMSData {}
@@ -185,15 +319,17 @@ export class SendSMSInputDTO extends SMSData {}
 export class SendBulkSMSInputDTO {
   @ApiProperty({
     type: String,
-    required: true,
-    description: 'The template to send the SMS with',
+    required: false,
+    description:
+      'Optional label for the batch. Each entry in messages carries its own text.',
   })
   messageTemplate: string
 
   @ApiProperty({
     type: [SMSData],
     required: true,
-    description: 'The messages to send',
+    description:
+      'Messages to send. Every message can target different recipients and use a different SIM.',
   })
   messages: SMSData[]
 }
@@ -248,74 +384,514 @@ export class ReceivedSMSDTO {
   receivedAtInMillis?: number
 }
 
-export class DeviceDTO {
-  @ApiProperty({ type: String })
+// The device summary embedded in message responses. Message queries populate
+// only these fields, so it is deliberately smaller than DeviceDTO.
+export class MessageDeviceDTO {
+  @ApiProperty({ type: String, description: 'Device id.' })
   _id: string
 
-  @ApiProperty({ type: Boolean })
+  @ApiProperty({
+    type: Boolean,
+    description: 'Whether the device may send and receive SMS.',
+  })
   enabled: boolean
 
-  @ApiProperty({ type: String })
+  @ApiProperty({ type: String, description: 'Device brand.', example: 'google' })
   brand: string
 
-  @ApiProperty({ type: String })
-  manufacturer: string
-
-  @ApiProperty({ type: String })
+  @ApiProperty({
+    type: String,
+    description: 'Device model.',
+    example: 'Pixel 7',
+  })
   model: string
 
-  @ApiProperty({ type: String })
+  @ApiProperty({ type: String, description: 'Android build id.' })
   buildId: string
 }
 
-export class RetrieveSMSDTO {
+export class BatteryInfoDTO {
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Battery level, 0 to 100.',
+  })
+  percentage?: number
+
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description: 'Whether the device was charging at the last heartbeat.',
+  })
+  isCharging?: boolean
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When this reading was taken.',
+  })
+  lastUpdated?: Date
+}
+
+export class NetworkInfoDTO {
   @ApiProperty({
     type: String,
-    required: true,
-    description: 'The id of the received SMS',
+    required: false,
+    enum: ['wifi', 'cellular', 'none'],
+    description: 'Connection the device last reported.',
   })
+  networkType?: string
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When this reading was taken.',
+  })
+  lastUpdated?: Date
+}
+
+export class AppVersionInfoDTO {
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'textbee app version name.',
+    example: '1.9.0',
+  })
+  versionName?: string
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'textbee app version code.',
+    example: 190,
+  })
+  versionCode?: number
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When this reading was taken.',
+  })
+  lastUpdated?: Date
+}
+
+export class DeviceUptimeInfoDTO {
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Milliseconds since the device booted.',
+  })
+  uptimeMillis?: number
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When this reading was taken.',
+  })
+  lastUpdated?: Date
+}
+
+export class MemoryInfoDTO {
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Free memory in bytes.',
+  })
+  freeBytes?: number
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Total memory in bytes.',
+  })
+  totalBytes?: number
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Maximum memory the app may use, in bytes.',
+  })
+  maxBytes?: number
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When this reading was taken.',
+  })
+  lastUpdated?: Date
+}
+
+export class StorageInfoDTO {
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Free storage in bytes.',
+  })
+  availableBytes?: number
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Total storage in bytes.',
+  })
+  totalBytes?: number
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When this reading was taken.',
+  })
+  lastUpdated?: Date
+}
+
+export class DeviceSystemInfoDTO {
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Device timezone.',
+    example: 'Africa/Addis_Ababa',
+  })
+  timezone?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Device locale.',
+    example: 'en_US',
+  })
+  locale?: string
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When this reading was taken.',
+  })
+  lastUpdated?: Date
+}
+
+// Full device as returned by the device endpoints. The push token and hardware
+// serial are stored but never returned.
+export class DeviceDTO {
+  @ApiProperty({
+    type: String,
+    description: 'Device id. Pass it as deviceId when sending.',
+  })
+  _id: string
+
+  @ApiProperty({ type: String, description: 'Owner account id.' })
+  user: string
+
+  @ApiProperty({
+    type: Boolean,
+    description:
+      'Whether the device may send and receive SMS. Sending to a disabled device fails.',
+  })
+  enabled: boolean
+
+  @ApiProperty({
+    type: Boolean,
+    description: 'Whether sends without a deviceId go out from this device.',
+  })
+  isDefault: boolean
+
+  @ApiProperty({ type: String, description: 'Device brand.', example: 'google' })
+  brand: string
+
+  @ApiProperty({
+    type: String,
+    description: 'Device manufacturer.',
+    example: 'Google',
+  })
+  manufacturer: string
+
+  @ApiProperty({
+    type: String,
+    description: 'Device model.',
+    example: 'Pixel 7',
+  })
+  model: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Your own label for the device.',
+    example: 'Office phone',
+  })
+  name?: string
+
+  @ApiProperty({ type: String, description: 'Android build id.' })
+  buildId: string
+
+  @ApiProperty({
+    type: String,
+    description: 'Operating system name.',
+    example: 'Android',
+  })
+  os: string
+
+  @ApiProperty({
+    type: String,
+    description: 'Android release version.',
+    example: '16',
+  })
+  osVersion: string
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Android SDK level.',
+    example: 36,
+  })
+  osApiLevel?: number
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    enum: ['reported', 'fingerprint', 'buildId'],
+    description: 'How osVersion was determined.',
+  })
+  osVersionSource?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Android build fingerprint.',
+  })
+  osBuildFingerprint?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'textbee app version name.',
+    example: '1.9.0',
+  })
+  appVersionName?: string
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'textbee app version code.',
+    example: 190,
+  })
+  appVersionCode?: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Messages this device has sent.',
+  })
+  sentSMSCount: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Messages this device has received.',
+  })
+  receivedSMSCount: number
+
+  @ApiProperty({
+    type: Boolean,
+    description: 'Whether the device reports heartbeats.',
+  })
+  heartbeatEnabled: boolean
+
+  @ApiProperty({
+    type: Number,
+    description: 'Minutes between heartbeats.',
+    example: 30,
+  })
+  heartbeatIntervalMinutes: number
+
+  @ApiProperty({
+    type: Boolean,
+    description:
+      'Whether incoming messages are forwarded to textbee. Required for received message history and webhooks.',
+  })
+  receiveSMSEnabled: boolean
+
+  @ApiProperty({
+    type: Number,
+    description: 'Seconds the device waits between messages in a batch.',
+  })
+  smsSendDelaySeconds: number
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description:
+      'Last heartbeat. A device silent for long is likely offline and sends will queue.',
+  })
+  lastHeartbeat?: Date
+
+  @ApiProperty({ type: BatteryInfoDTO, required: false })
+  batteryInfo?: BatteryInfoDTO
+
+  @ApiProperty({ type: NetworkInfoDTO, required: false })
+  networkInfo?: NetworkInfoDTO
+
+  @ApiProperty({ type: AppVersionInfoDTO, required: false })
+  appVersionInfo?: AppVersionInfoDTO
+
+  @ApiProperty({ type: DeviceUptimeInfoDTO, required: false })
+  deviceUptimeInfo?: DeviceUptimeInfoDTO
+
+  @ApiProperty({ type: MemoryInfoDTO, required: false })
+  memoryInfo?: MemoryInfoDTO
+
+  @ApiProperty({ type: StorageInfoDTO, required: false })
+  storageInfo?: StorageInfoDTO
+
+  @ApiProperty({ type: DeviceSystemInfoDTO, required: false })
+  systemInfo?: DeviceSystemInfoDTO
+
+  @ApiProperty({
+    type: SimInfoCollectionDTO,
+    required: false,
+    description: 'SIMs installed in the device.',
+  })
+  simInfo?: SimInfoCollectionDTO
+
+  @ApiProperty({ type: Date, description: 'When the device was registered.' })
+  createdAt: Date
+
+  @ApiProperty({ type: Date, description: 'When the device was last updated.' })
+  updatedAt: Date
+}
+
+export class RetrieveSMSDTO {
+  @ApiProperty({ type: String, description: 'Message id.' })
   _id: string
 
   @ApiProperty({
     type: String,
-    required: true,
-    description: 'The message received',
+    required: false,
+    description: 'Message text. Empty when the message is end to end encrypted.',
   })
   message: string
 
   @ApiProperty({
-    type: DeviceDTO,
-    required: true,
-    description: 'The device that received the message',
+    type: MessageDeviceDTO,
+    description: 'Device that sent or received the message.',
   })
-  device: DeviceDTO
+  device: MessageDeviceDTO
 
   @ApiProperty({
     type: String,
-    required: true,
-    description: 'The phone number of the sender',
+    enum: ['sent', 'received'],
+    description: 'Direction of the message.',
   })
-  sender: string
+  type: string
+
+  @ApiProperty({
+    type: String,
+    enum: [
+      'pending',
+      'dispatched',
+      'sent',
+      'delivered',
+      'failed',
+      'unknown',
+      'received',
+    ],
+    description:
+      'Delivery state. Incoming messages are always received. Outgoing messages move from pending to sent, then to delivered when the carrier confirms.',
+  })
+  status: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Sender number. Set on received messages.',
+  })
+  sender?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Destination number. Set on sent messages.',
+  })
+  recipient?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Id of the batch this message was sent in.',
+  })
+  smsBatch?: string
+
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description:
+      'Whether the body is end to end encrypted. Encrypted bodies can only be read by your own client.',
+  })
+  encrypted?: boolean
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'SIM the message was sent from.',
+  })
+  simSubscriptionId?: number
 
   @ApiProperty({
     type: Date,
-    required: true,
-    description: 'The time the message was received',
+    required: false,
+    description: 'When the message was received. Received messages only.',
   })
-  receivedAt: Date
+  receivedAt?: Date
 
   @ApiProperty({
     type: Date,
-    required: true,
-    description: 'The time the message was created',
+    required: false,
+    description: 'When the send was requested. Sent messages only.',
   })
+  requestedAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When the send job reached the device.',
+  })
+  dispatchedAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When the device reported the message as sent.',
+  })
+  sentAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When the carrier confirmed delivery.',
+  })
+  deliveredAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When the message failed.',
+  })
+  failedAt?: Date
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Failure code reported by the device.',
+  })
+  errorCode?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Failure reason reported by the device.',
+  })
+  errorMessage?: string
+
+  @ApiProperty({ type: Date, description: 'When the record was created.' })
   createdAt: Date
 
-  @ApiProperty({
-    type: Date,
-    required: true,
-    description: 'The time the message was last updated',
-  })
+  @ApiProperty({ type: Date, description: 'When the record was last updated.' })
   updatedAt: Date
 }
 
@@ -584,4 +1160,195 @@ export class HeartbeatResponseDTO {
     description: 'Device name (if updated)',
   })
   name?: string
+}
+
+export class GatewayStatsDTO {
+  @ApiProperty({
+    type: Number,
+    description: 'Messages sent across all your devices.',
+  })
+  totalSentSMSCount: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Messages received across all your devices.',
+  })
+  totalReceivedSMSCount: number
+
+  @ApiProperty({ type: Number, description: 'Devices on your account.' })
+  totalDeviceCount: number
+
+  @ApiProperty({ type: Number, description: 'API keys on your account.' })
+  totalApiKeyCount: number
+}
+
+export class GatewayStatsResponseDTO {
+  @ApiProperty({ type: GatewayStatsDTO })
+  data: GatewayStatsDTO
+}
+
+export class DeviceListResponseDTO {
+  @ApiProperty({ type: [DeviceDTO] })
+  data: DeviceDTO[]
+}
+
+export class DeviceResponseDTO {
+  @ApiProperty({ type: DeviceDTO })
+  data: DeviceDTO
+}
+
+export class SuccessResultDTO {
+  @ApiProperty({ type: Boolean, description: 'Whether the action succeeded.' })
+  success: boolean
+}
+
+export class SuccessResponseDTO {
+  @ApiProperty({ type: SuccessResultDTO })
+  data: SuccessResultDTO
+}
+
+export class SendSMSResultDTO {
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description: 'Whether the batch was accepted. Queued sends only.',
+  })
+  success?: boolean
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Human readable outcome. Queued sends only.',
+    example: 'SMS added to queue for processing',
+  })
+  message?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      'Batch id. Pass it to GET /gateway/devices/{id}/sms-batch/{smsBatchId} to follow delivery. Queued sends only.',
+  })
+  smsBatchId?: string
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Number of recipients in the batch. Queued sends only.',
+  })
+  recipientCount?: number
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description:
+      'Messages pushed to the device. Returned instead of the queue fields when the instance dispatches immediately.',
+  })
+  successCount?: number
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Messages that could not be pushed to the device.',
+  })
+  failureCount?: number
+}
+
+export class SendSMSResponseDTO {
+  @ApiProperty({ type: SendSMSResultDTO })
+  data: SendSMSResultDTO
+}
+
+export class SMSResponseDTO {
+  @ApiProperty({ type: RetrieveSMSDTO })
+  data: RetrieveSMSDTO
+}
+
+export class SMSBatchDTO {
+  @ApiProperty({ type: String, description: 'Batch id.' })
+  _id: string
+
+  @ApiProperty({ type: String, description: 'Owner account id.' })
+  user: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Message text sent to every recipient in the batch.',
+  })
+  message?: string
+
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description: 'Whether the body is end to end encrypted.',
+  })
+  encrypted?: boolean
+
+  @ApiProperty({ type: Number, description: 'Recipients in the batch.' })
+  recipientCount: number
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Short preview of the recipient list.',
+    example: '+2519xxxxxxxx and 3 others',
+  })
+  recipientPreview?: string
+
+  @ApiProperty({ type: Number, description: 'Messages sent so far.' })
+  successCount: number
+
+  @ApiProperty({ type: Number, description: 'Messages that failed.' })
+  failureCount: number
+
+  @ApiProperty({
+    type: String,
+    enum: [
+      'pending',
+      'processing',
+      'completed',
+      'partial_success',
+      'failed',
+      'unknown',
+    ],
+    description: 'Progress of the batch as a whole.',
+  })
+  status: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Failure reason when the batch failed.',
+  })
+  error?: string
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When the batch finished.',
+  })
+  completedAt?: Date
+
+  @ApiProperty({ type: Date, description: 'When the batch was created.' })
+  createdAt: Date
+
+  @ApiProperty({ type: Date, description: 'When the batch was last updated.' })
+  updatedAt: Date
+}
+
+export class SMSBatchResultDTO {
+  @ApiProperty({ type: SMSBatchDTO, description: 'The batch itself.' })
+  batch: SMSBatchDTO
+
+  @ApiProperty({
+    type: [RetrieveSMSDTO],
+    description: 'Every message in the batch, one per recipient.',
+  })
+  messages: RetrieveSMSDTO[]
+}
+
+export class SMSBatchResponseDTO {
+  @ApiProperty({ type: SMSBatchResultDTO })
+  data: SMSBatchResultDTO
 }

--- a/api/src/gateway/gateway.dto.ts
+++ b/api/src/gateway/gateway.dto.ts
@@ -721,25 +721,53 @@ export class DeviceDTO {
   })
   lastHeartbeat?: Date
 
-  @ApiProperty({ type: BatteryInfoDTO, required: false })
+  @ApiProperty({
+    type: BatteryInfoDTO,
+    required: false,
+    description: 'Battery level at the last heartbeat.',
+  })
   batteryInfo?: BatteryInfoDTO
 
-  @ApiProperty({ type: NetworkInfoDTO, required: false })
+  @ApiProperty({
+    type: NetworkInfoDTO,
+    required: false,
+    description: 'Connection the device was on at the last heartbeat.',
+  })
   networkInfo?: NetworkInfoDTO
 
-  @ApiProperty({ type: AppVersionInfoDTO, required: false })
+  @ApiProperty({
+    type: AppVersionInfoDTO,
+    required: false,
+    description: 'textbee app version running on the device.',
+  })
   appVersionInfo?: AppVersionInfoDTO
 
-  @ApiProperty({ type: DeviceUptimeInfoDTO, required: false })
+  @ApiProperty({
+    type: DeviceUptimeInfoDTO,
+    required: false,
+    description: 'How long the device has been up.',
+  })
   deviceUptimeInfo?: DeviceUptimeInfoDTO
 
-  @ApiProperty({ type: MemoryInfoDTO, required: false })
+  @ApiProperty({
+    type: MemoryInfoDTO,
+    required: false,
+    description: 'Memory reported at the last heartbeat.',
+  })
   memoryInfo?: MemoryInfoDTO
 
-  @ApiProperty({ type: StorageInfoDTO, required: false })
+  @ApiProperty({
+    type: StorageInfoDTO,
+    required: false,
+    description: 'Storage reported at the last heartbeat.',
+  })
   storageInfo?: StorageInfoDTO
 
-  @ApiProperty({ type: DeviceSystemInfoDTO, required: false })
+  @ApiProperty({
+    type: DeviceSystemInfoDTO,
+    required: false,
+    description: 'Timezone and locale of the device.',
+  })
   systemInfo?: DeviceSystemInfoDTO
 
   @ApiProperty({
@@ -1128,7 +1156,11 @@ export class HeartbeatInputDTO {
   })
   smsSendDelaySeconds?: number
 
-  @ApiProperty({ type: SimInfoCollectionDTO, required: false })
+  @ApiProperty({
+    type: SimInfoCollectionDTO,
+    required: false,
+    description: 'SIMs installed in the device at the time of the heartbeat.',
+  })
   simInfo?: SimInfoCollectionDTO
 }
 
@@ -1183,17 +1215,17 @@ export class GatewayStatsDTO {
 }
 
 export class GatewayStatsResponseDTO {
-  @ApiProperty({ type: GatewayStatsDTO })
+  @ApiProperty({ type: GatewayStatsDTO, description: 'Account totals.' })
   data: GatewayStatsDTO
 }
 
 export class DeviceListResponseDTO {
-  @ApiProperty({ type: [DeviceDTO] })
+  @ApiProperty({ type: [DeviceDTO], description: 'Your devices.' })
   data: DeviceDTO[]
 }
 
 export class DeviceResponseDTO {
-  @ApiProperty({ type: DeviceDTO })
+  @ApiProperty({ type: DeviceDTO, description: 'The device.' })
   data: DeviceDTO
 }
 
@@ -1203,7 +1235,7 @@ export class SuccessResultDTO {
 }
 
 export class SuccessResponseDTO {
-  @ApiProperty({ type: SuccessResultDTO })
+  @ApiProperty({ type: SuccessResultDTO, description: 'Outcome of the action.' })
   data: SuccessResultDTO
 }
 
@@ -1255,12 +1287,12 @@ export class SendSMSResultDTO {
 }
 
 export class SendSMSResponseDTO {
-  @ApiProperty({ type: SendSMSResultDTO })
+  @ApiProperty({ type: SendSMSResultDTO, description: 'Outcome of the send.' })
   data: SendSMSResultDTO
 }
 
 export class SMSResponseDTO {
-  @ApiProperty({ type: RetrieveSMSDTO })
+  @ApiProperty({ type: RetrieveSMSDTO, description: 'The message.' })
   data: RetrieveSMSDTO
 }
 
@@ -1349,6 +1381,9 @@ export class SMSBatchResultDTO {
 }
 
 export class SMSBatchResponseDTO {
-  @ApiProperty({ type: SMSBatchResultDTO })
+  @ApiProperty({
+    type: SMSBatchResultDTO,
+    description: 'The batch and the messages in it.',
+  })
   data: SMSBatchResultDTO
 }

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,12 +1,13 @@
 import 'dotenv/config'
 import * as crypto from 'crypto'
-import { VersioningType, Logger } from '@nestjs/common'
+import { Logger } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 import { AppModule } from './app.module'
 import * as firebase from 'firebase-admin'
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
+import { SwaggerModule } from '@nestjs/swagger'
 import * as express from 'express'
 import { NestExpressApplication } from '@nestjs/platform-express'
+import { applyApiConventions, buildSwaggerConfig } from './openapi/swagger-config'
 
 // Ensure crypto is available globally for @nestjs/schedule
 if (typeof globalThis.crypto === 'undefined') {
@@ -30,26 +31,12 @@ async function bootstrap() {
   const app: NestExpressApplication = await NestFactory.create(AppModule)
   const PORT = process.env.PORT || 3001
 
-  app.setGlobalPrefix('api')
-  app.enableVersioning({
-    defaultVersion: '1',
-    type: VersioningType.URI,
-  })
+  applyApiConventions(app)
 
-  const config = new DocumentBuilder()
-    .setTitle('TextBee API Docs')
-    .setDescription('TextBee - Android SMS Gateway API Docs')
-    .setVersion('1.0')
-    .addBearerAuth()
-    .addApiKey(
-      {
-        type: 'apiKey',
-        name: 'x-api-key',
-        in: 'header',
-      },
-      'x-api-key',
-    )
-    .build()
+  const config = buildSwaggerConfig({
+    title: 'TextBee API Docs',
+    description: 'TextBee - Android SMS Gateway API Docs',
+  })
   const document = SwaggerModule.createDocument(app, config)
   // Every route that carries the spec itself, including swagger-ui-init.js,
   // which embeds the whole document and is otherwise cached as a static .js

--- a/api/src/openapi/build-public-document.spec.ts
+++ b/api/src/openapi/build-public-document.spec.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { OpenAPIObject } from '@nestjs/swagger'
+import {
+  createPublicOpenApiDocument,
+  serializeDocument,
+} from './build-public-document'
+import { PUBLIC_OPERATION_KEYS, toOperationKey } from './public-operations'
+import { API_KEY_SECURITY_SCHEME } from './swagger-config'
+
+const COMMITTED_SPEC_PATH = join(__dirname, '..', '..', 'openapi.json')
+const REGENERATE_HINT = 'Run `pnpm run export:openapi` and commit openapi.json.'
+
+// Preview mode means no Mongo, no Redis, and no env file, but building the
+// module graph still takes longer than the default jest timeout.
+jest.setTimeout(60_000)
+
+describe('public openapi document', () => {
+  let document: OpenAPIObject
+  let operations: Array<[string, any]>
+
+  beforeAll(async () => {
+    document = await createPublicOpenApiDocument()
+    operations = Object.entries(document.paths).flatMap(([path, pathItem]) =>
+      Object.entries(pathItem).map(
+        ([method, operation]) =>
+          [toOperationKey(method, path), operation] as [string, any],
+      ),
+    )
+  })
+
+  it('exposes exactly the allowlisted operations', () => {
+    expect(operations.map(([key]) => key).sort()).toEqual(
+      [...PUBLIC_OPERATION_KEYS].sort(),
+    )
+  })
+
+  it('promotes no deprecated operation', () => {
+    const deprecated = operations
+      .filter(([, operation]) => operation.deprecated)
+      .map(([key]) => key)
+
+    expect(deprecated).toEqual([])
+  })
+
+  it('offers the api key as the only way to authenticate', () => {
+    expect(Object.keys(document.components.securitySchemes)).toEqual([
+      API_KEY_SECURITY_SCHEME,
+    ])
+  })
+
+  it('gives every operation a summary', () => {
+    const unsummarized = operations
+      .filter(([, operation]) => !operation.summary?.trim())
+      .map(([key]) => key)
+
+    expect(unsummarized).toEqual([])
+  })
+
+  it('gives every request body a schema with fields', () => {
+    const schemas = document.components.schemas ?? {}
+
+    const empty = operations
+      .filter(([, operation]) => operation.requestBody)
+      .filter(([, operation]) => {
+        const schema =
+          operation.requestBody.content?.['application/json']?.schema ?? {}
+        const name = schema.$ref?.split('/').pop()
+        const resolved = name ? schemas[name] : schema
+        return Object.keys(resolved?.['properties'] ?? {}).length === 0
+      })
+      .map(([key]) => key)
+
+    expect(empty).toEqual([])
+  })
+
+  // A mismatch means a decorator changed without the spec being regenerated.
+  it(`matches the committed openapi.json. ${REGENERATE_HINT}`, () => {
+    expect(serializeDocument(document)).toEqual(
+      readFileSync(COMMITTED_SPEC_PATH, 'utf8'),
+    )
+  })
+})

--- a/api/src/openapi/build-public-document.ts
+++ b/api/src/openapi/build-public-document.ts
@@ -1,0 +1,187 @@
+import { NestFactory } from '@nestjs/core'
+import { OpenAPIObject, SwaggerModule } from '@nestjs/swagger'
+import { AppModule } from '../app.module'
+import {
+  API_KEY_SECURITY_SCHEME,
+  API_TAGS,
+  applyApiConventions,
+  buildSwaggerConfig,
+} from './swagger-config'
+import { PUBLIC_OPERATION_KEYS, toOperationKey } from './public-operations'
+
+const PUBLIC_TITLE = 'textbee API'
+const PUBLIC_DESCRIPTION =
+  'Send and receive SMS through an Android phone you own. Authenticate every request with an API key from your textbee dashboard, sent as the x-api-key header.'
+const PUBLIC_SERVER_URL = 'https://api.textbee.dev'
+const PUBLIC_TAG_NAMES = ['gateway', 'webhooks']
+
+const HTTP_METHODS = ['get', 'post', 'patch', 'put', 'delete'] as const
+
+/**
+ * Generates the spec published at textbee.dev/openapi.json.
+ *
+ * Preview mode builds the module graph and reads the controller decorators
+ * without instantiating a single provider, so this runs with no Mongo, no
+ * Redis, and no env file. The document is filtered to the public allowlist
+ * afterwards; the runtime Swagger UI keeps serving everything.
+ */
+export async function createPublicOpenApiDocument(): Promise<OpenAPIObject> {
+  const app = await NestFactory.create(AppModule, {
+    preview: true,
+    logger: false,
+    abortOnError: false,
+  })
+
+  try {
+    applyApiConventions(app)
+
+    const document = SwaggerModule.createDocument(
+      app,
+      buildSwaggerConfig({
+        title: PUBLIC_TITLE,
+        description: PUBLIC_DESCRIPTION,
+        servers: [PUBLIC_SERVER_URL],
+      }),
+    )
+
+    keepOnlyPublicOperations(document)
+    assertNoDeprecatedOperations(document)
+    keepOnlyApiKeySecurity(document)
+    keepOnlyPublicTags(document)
+    pruneUnreferencedSchemas(document)
+
+    return document
+  } finally {
+    await app.close()
+  }
+}
+
+export function serializeDocument(document: OpenAPIObject): string {
+  return `${JSON.stringify(document, null, 2)}\n`
+}
+
+function keepOnlyPublicOperations(document: OpenAPIObject): void {
+  const wanted = new Set(PUBLIC_OPERATION_KEYS)
+  const found = new Set<string>()
+
+  for (const [path, pathItem] of Object.entries(document.paths ?? {})) {
+    for (const method of HTTP_METHODS) {
+      if (!pathItem[method]) continue
+
+      const key = toOperationKey(method, path)
+      if (wanted.has(key)) {
+        found.add(key)
+      } else {
+        delete pathItem[method]
+      }
+    }
+
+    if (!HTTP_METHODS.some((method) => pathItem[method])) {
+      delete document.paths[path]
+    }
+  }
+
+  const missing = PUBLIC_OPERATION_KEYS.filter((key) => !found.has(key))
+  if (missing.length > 0) {
+    throw new Error(
+      `Allowlisted operations are not in the generated document, so a route was renamed or removed: ${missing.join(
+        ', ',
+      )}. Fix the route or update src/openapi/public-operations.ts.`,
+    )
+  }
+}
+
+function assertNoDeprecatedOperations(document: OpenAPIObject): void {
+  const deprecated = eachOperation(document)
+    .filter(([, operation]) => operation.deprecated === true)
+    .map(([key]) => key)
+
+  if (deprecated.length > 0) {
+    throw new Error(
+      `The public spec must not promote deprecated operations: ${deprecated.join(
+        ', ',
+      )}.`,
+    )
+  }
+}
+
+/**
+ * Bearer auth is the dashboard session flow, which no public consumer can
+ * obtain. A single scheme also imports cleanly into GPT Actions and Postman.
+ */
+function keepOnlyApiKeySecurity(document: OpenAPIObject): void {
+  const schemes = document.components?.securitySchemes ?? {}
+  for (const name of Object.keys(schemes)) {
+    if (name !== API_KEY_SECURITY_SCHEME) delete schemes[name]
+  }
+
+  for (const [, operation] of eachOperation(document)) {
+    if (!operation.security) continue
+    operation.security = operation.security.filter((requirement) =>
+      Object.keys(requirement).includes(API_KEY_SECURITY_SCHEME),
+    )
+  }
+}
+
+function keepOnlyPublicTags(document: OpenAPIObject): void {
+  document.tags = API_TAGS.filter((tag) =>
+    PUBLIC_TAG_NAMES.includes(tag.name),
+  ).map((tag) => ({ ...tag }))
+}
+
+/** Drops schemas only the removed operations referenced. */
+function pruneUnreferencedSchemas(document: OpenAPIObject): void {
+  const schemas = document.components?.schemas
+  if (!schemas) return
+
+  const reachable = new Set<string>()
+  const queue = collectSchemaRefs(document.paths)
+
+  while (queue.length > 0) {
+    const name = queue.pop()
+    if (!name || reachable.has(name) || !schemas[name]) continue
+    reachable.add(name)
+    queue.push(...collectSchemaRefs(schemas[name]))
+  }
+
+  for (const name of Object.keys(schemas)) {
+    if (!reachable.has(name)) delete schemas[name]
+  }
+}
+
+function collectSchemaRefs(value: unknown): string[] {
+  const refs: string[] = []
+
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(walk)
+      return
+    }
+    if (!node || typeof node !== 'object') return
+
+    for (const [key, child] of Object.entries(node)) {
+      if (key === '$ref' && typeof child === 'string') {
+        const name = child.split('/').pop()
+        if (name) refs.push(name)
+        continue
+      }
+      walk(child)
+    }
+  }
+
+  walk(value)
+  return refs
+}
+
+function eachOperation(document: OpenAPIObject): Array<[string, any]> {
+  const entries: Array<[string, any]> = []
+
+  for (const [path, pathItem] of Object.entries(document.paths ?? {})) {
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method]
+      if (operation) entries.push([toOperationKey(method, path), operation])
+    }
+  }
+
+  return entries
+}

--- a/api/src/openapi/export-openapi.ts
+++ b/api/src/openapi/export-openapi.ts
@@ -1,0 +1,27 @@
+import { writeFileSync } from 'fs'
+import { join } from 'path'
+import {
+  createPublicOpenApiDocument,
+  serializeDocument,
+} from './build-public-document'
+
+// api/openapi.json, whether this runs from src via ts-node or from dist.
+const OUTPUT_PATH = join(__dirname, '..', '..', 'openapi.json')
+
+async function exportOpenApi(): Promise<void> {
+  const document = await createPublicOpenApiDocument()
+  writeFileSync(OUTPUT_PATH, serializeDocument(document))
+
+  const operationCount = Object.values(document.paths).reduce(
+    (total, pathItem) => total + Object.keys(pathItem).length,
+    0,
+  )
+  console.log(`Wrote ${operationCount} operations to ${OUTPUT_PATH}`)
+}
+
+exportOpenApi()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/api/src/openapi/public-operations.ts
+++ b/api/src/openapi/public-operations.ts
@@ -1,0 +1,48 @@
+export type HttpMethod = 'get' | 'post' | 'patch' | 'delete' | 'put'
+
+export interface PublicOperation {
+  method: HttpMethod
+  /** Controller path as written in the code, without the /api/v1 prefix. */
+  path: string
+}
+
+/**
+ * The only operations the published spec exposes. An allowlist rather than a
+ * tag filter, so a new endpoint stays private until someone adds it here.
+ *
+ * Deliberately absent: the device app contract (pairing, heartbeat,
+ * receive-sms, sms-status), every deprecated alias, and everything the
+ * dashboard owns (auth, billing, support, device writes).
+ */
+export const PUBLIC_OPERATIONS: readonly PublicOperation[] = [
+  { method: 'post', path: '/gateway/send-sms' },
+  { method: 'post', path: '/gateway/send-bulk-sms' },
+  { method: 'get', path: '/gateway/devices' },
+  { method: 'get', path: '/gateway/devices/:id' },
+  { method: 'get', path: '/gateway/devices/:id/messages' },
+  { method: 'get', path: '/gateway/devices/:id/sms/:smsId' },
+  { method: 'get', path: '/gateway/devices/:id/sms-batch/:smsBatchId' },
+  { method: 'get', path: '/gateway/stats' },
+  { method: 'get', path: '/webhooks' },
+  { method: 'post', path: '/webhooks' },
+  { method: 'get', path: '/webhooks/:webhookId' },
+  { method: 'patch', path: '/webhooks/:webhookId' },
+  { method: 'delete', path: '/webhooks/:webhookId' },
+  { method: 'get', path: '/webhooks/notifications' },
+]
+
+export const API_PATH_PREFIX = '/api/v1'
+
+/** Turns `/gateway/devices/:id` into the `/api/v1/gateway/devices/{id}` the document uses. */
+export function toDocumentPath(path: string): string {
+  const withBraces = path.replace(/:([A-Za-z0-9_]+)/g, '{$1}')
+  return `${API_PATH_PREFIX}${withBraces}`
+}
+
+export function toOperationKey(method: string, documentPath: string): string {
+  return `${method.toLowerCase()} ${documentPath}`
+}
+
+export const PUBLIC_OPERATION_KEYS: readonly string[] = PUBLIC_OPERATIONS.map(
+  (operation) => toOperationKey(operation.method, toDocumentPath(operation.path)),
+)

--- a/api/src/openapi/swagger-config.ts
+++ b/api/src/openapi/swagger-config.ts
@@ -38,6 +38,11 @@ export interface SwaggerConfigOptions {
   servers?: string[]
 }
 
+const LICENSE = {
+  name: 'MIT',
+  url: 'https://github.com/vernu/textbee/blob/main/LICENSE',
+} as const
+
 // The server and the openapi exporter both call this, so the documented paths
 // cannot drift from the ones the app actually serves.
 export function applyApiConventions(app: INestApplication): void {
@@ -58,6 +63,7 @@ export function buildSwaggerConfig({
     .setTitle(title)
     .setDescription(description)
     .setVersion(version)
+    .setLicense(LICENSE.name, LICENSE.url)
     .addBearerAuth()
     .addApiKey(
       {

--- a/api/src/openapi/swagger-config.ts
+++ b/api/src/openapi/swagger-config.ts
@@ -1,0 +1,82 @@
+import { INestApplication, VersioningType } from '@nestjs/common'
+import { DocumentBuilder } from '@nestjs/swagger'
+
+export const API_KEY_SECURITY_SCHEME = 'x-api-key'
+export const BEARER_SECURITY_SCHEME = 'bearer'
+
+export const API_TAGS: ReadonlyArray<{ name: string; description: string }> = [
+  {
+    name: 'gateway',
+    description:
+      'Send SMS and read message history through the Android devices paired with your account.',
+  },
+  {
+    name: 'webhooks',
+    description:
+      'Subscribe to SMS events and inspect the delivery attempts textbee made for them.',
+  },
+  {
+    name: 'auth',
+    description:
+      'Accounts, sessions, and API keys. Used by the textbee dashboard.',
+  },
+  {
+    name: 'billing',
+    description: 'Plans, the current subscription, and checkout.',
+  },
+  {
+    name: 'support',
+    description: 'Contact support and request account deletion.',
+  },
+]
+
+export interface SwaggerConfigOptions {
+  title: string
+  description: string
+  version?: string
+  /** Absolute base URLs the operations can be called against. */
+  servers?: string[]
+}
+
+// The server and the openapi exporter both call this, so the documented paths
+// cannot drift from the ones the app actually serves.
+export function applyApiConventions(app: INestApplication): void {
+  app.setGlobalPrefix('api')
+  app.enableVersioning({
+    defaultVersion: '1',
+    type: VersioningType.URI,
+  })
+}
+
+export function buildSwaggerConfig({
+  title,
+  description,
+  version = '1.0',
+  servers = [],
+}: SwaggerConfigOptions) {
+  const builder = new DocumentBuilder()
+    .setTitle(title)
+    .setDescription(description)
+    .setVersion(version)
+    .addBearerAuth()
+    .addApiKey(
+      {
+        type: 'apiKey',
+        name: 'x-api-key',
+        in: 'header',
+        description:
+          'API key from your textbee dashboard, sent on every request.',
+      },
+      API_KEY_SECURITY_SCHEME,
+    )
+
+  for (const tag of API_TAGS) {
+    builder.addTag(tag.name, tag.description)
+  }
+
+  for (const server of servers) {
+    builder.addServer(server)
+  }
+
+  return builder.build()
+}

--- a/api/src/support/dto/create-support-message.dto.ts
+++ b/api/src/support/dto/create-support-message.dto.ts
@@ -1,3 +1,4 @@
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger'
 import {
   IsEmail,
   IsEnum,
@@ -15,38 +16,73 @@ export enum SupportCategory {
 }
 
 export class CreateSupportMessageDto {
+  // Always taken from the token, never from the body.
+  @ApiHideProperty()
   @IsOptional()
   @IsString()
   user?: string
 
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Your name, so support knows who is asking.',
+  })
   @IsNotEmpty()
   @IsString()
   name: string
 
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Email address to reply to. The confirmation goes here.',
+  })
   @IsNotEmpty()
   @IsEmail()
   email: string
 
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Phone number, if you want to be called back.',
+  })
   @IsOptional()
   @IsString()
   phone?: string
 
+  @ApiProperty({
+    enum: SupportCategory,
+    required: true,
+    description: 'What the request is about.',
+  })
   @IsNotEmpty()
   @IsEnum(SupportCategory)
   category: SupportCategory
 
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'What you need help with.',
+  })
   @IsNotEmpty()
   @IsString()
   message: string
 
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Cloudflare Turnstile token from the support form.',
+  })
   @IsNotEmpty()
   @IsString()
   turnstileToken: string
 
+  // Read from the request, never from the body.
+  @ApiHideProperty()
   @IsOptional()
   @IsString()
   ip?: string
 
+  @ApiHideProperty()
   @IsOptional()
   @IsString()
   userAgent?: string

--- a/api/src/support/dto/request-account-deletion.dto.ts
+++ b/api/src/support/dto/request-account-deletion.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class RequestAccountDeletionDto {
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Why you are closing the account.',
+  })
+  message: string
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: 'Cloudflare Turnstile token from the form.',
+  })
+  turnstileToken: string
+}
+
+export class SupportMessageResponseDTO {
+  @ApiProperty({
+    type: String,
+    description: 'Confirmation that the request was recorded.',
+    example: 'Support request submitted successfully',
+  })
+  message: string
+}

--- a/api/src/support/support.controller.ts
+++ b/api/src/support/support.controller.ts
@@ -1,15 +1,26 @@
 import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common'
-import { ApiBearerAuth, ApiSecurity } from '@nestjs/swagger'
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger'
 import {
   CreateSupportMessageDto,
   SupportCategory,
 } from './dto/create-support-message.dto'
+import {
+  RequestAccountDeletionDto,
+  SupportMessageResponseDTO,
+} from './dto/request-account-deletion.dto'
 import { SupportService } from './support.service'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { Request } from 'express'
 import { AuthGuard } from '../auth/guards/auth.guard'
 import { TurnstileService } from '../common/turnstile.service'
 
+@ApiTags('support')
 @Controller('support')
 export class SupportController {
   constructor(
@@ -17,6 +28,25 @@ export class SupportController {
     private readonly turnstileService: TurnstileService,
   ) {}
 
+  @ApiOperation({
+    summary: 'Contact support',
+    description:
+      'Sends a message to the textbee support team and emails you a confirmation. The account behind the credentials is attached automatically.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'The request was recorded.',
+    type: SupportMessageResponseDTO,
+  })
+  @ApiResponse({ status: 400, description: 'The Turnstile check failed.' })
+  @ApiResponse({
+    status: 401,
+    description: 'Missing, invalid, or revoked API key.',
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Too many support requests from this account recently.',
+  })
   @ApiBearerAuth()
   @ApiSecurity('x-api-key')
   @UseGuards(AuthGuard)
@@ -40,11 +70,23 @@ export class SupportController {
     return this.supportService.createSupportMessage(createSupportMessageDto)
   }
 
+  @ApiOperation({
+    summary: 'Request account deletion',
+    description:
+      'Files a deletion request for the signed in account. Requires a dashboard session, not an API key.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'The deletion request was recorded.',
+    type: SupportMessageResponseDTO,
+  })
+  @ApiResponse({ status: 400, description: 'The Turnstile check failed.' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid session.' })
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard)
   @Post('request-account-deletion')
   async requestAccountDeletion(
-    @Body() body: { message: string; turnstileToken: string },
+    @Body() body: RequestAccountDeletionDto,
     @Req() req: Request,
   ) {
     await this.turnstileService.verify(body.turnstileToken)

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -1,4 +1,7 @@
 import { Controller } from '@nestjs/common'
+import { ApiExcludeController } from '@nestjs/swagger'
 
+// No routes yet, so it would otherwise show up as an empty tag in the docs.
+@ApiExcludeController()
 @Controller('users')
 export class UsersController {}

--- a/api/src/webhook/webhook.controller.ts
+++ b/api/src/webhook/webhook.controller.ts
@@ -11,9 +11,40 @@ import {
   Query,
 } from '@nestjs/common'
 import { WebhookService } from './webhook.service'
-import { ApiBearerAuth, ApiSecurity, ApiTags } from '@nestjs/swagger'
-import { CreateWebhookDto, UpdateWebhookDto } from './webhook.dto'
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger'
+import {
+  CreateWebhookDto,
+  UpdateWebhookDto,
+  WebhookDeletedResponseDTO,
+  WebhookListResponseDTO,
+  WebhookNotificationListResponseDTO,
+  WebhookResponseDTO,
+} from './webhook.dto'
+import { WebhookEvent } from './webhook-event.enum'
 import { AuthGuard } from 'src/auth/guards/auth.guard'
+
+const WEBHOOK_ID_PARAM = {
+  name: 'webhookId',
+  description: 'Subscription id, from GET /webhooks.',
+} as const
+
+const UNAUTHORIZED_RESPONSE = {
+  status: 401,
+  description: 'Missing, invalid, or revoked API key.',
+} as const
+
+const WEBHOOK_NOT_FOUND_RESPONSE = {
+  status: 404,
+  description: 'No webhook subscription with that id on your account.',
+} as const
 
 @ApiTags('webhooks')
 @ApiBearerAuth()
@@ -22,6 +53,17 @@ import { AuthGuard } from 'src/auth/guards/auth.guard'
 export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}
 
+  @ApiOperation({
+    summary: 'List your webhook subscriptions',
+    description:
+      'Every subscription on your account, deleted ones excluded. Each one says which events it receives and where they are delivered.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Your subscriptions.',
+    type: WebhookListResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @Get()
   @UseGuards(AuthGuard)
   async getWebhooks(@Request() req) {
@@ -30,6 +72,74 @@ export class WebhookController {
     })
     return { data }
   }
+
+  @ApiOperation({
+    summary: 'List webhook delivery attempts',
+    description:
+      'Delivery history across your subscriptions, newest first. Use it to see what textbee sent, what your endpoint answered, and whether a retry is pending. History is kept for subscriptions you have since deleted.',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: 'Page to return. Default 1.',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Records per page. Default 10.',
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['pending', 'retrying', 'delivered', 'failed'],
+    description: 'Only return deliveries in this state.',
+  })
+  @ApiQuery({
+    name: 'eventType',
+    required: false,
+    enum: WebhookEvent,
+    description: 'Only return deliveries for this event.',
+  })
+  @ApiQuery({
+    name: 'deviceId',
+    required: false,
+    type: String,
+    description: 'Only return deliveries for messages from this device.',
+  })
+  @ApiQuery({
+    name: 'start',
+    required: false,
+    type: String,
+    description:
+      'Start of the time range, ISO 8601. Applied only together with end.',
+    example: '2026-08-01T00:00:00Z',
+  })
+  @ApiQuery({
+    name: 'end',
+    required: false,
+    type: String,
+    description: 'End of the time range, ISO 8601.',
+    example: '2026-08-31T23:59:59Z',
+  })
+  @ApiQuery({
+    name: 'webhookSubscriptionId',
+    required: false,
+    type: String,
+    description: 'Only return deliveries for one subscription.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'A page of delivery records.',
+    type: WebhookNotificationListResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'deviceId or webhookSubscriptionId is not a valid id.',
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(WEBHOOK_NOT_FOUND_RESPONSE)
   @Get('notifications')
   @UseGuards(AuthGuard)
   async getWebhookNotifications(
@@ -56,6 +166,19 @@ export class WebhookController {
     })
     return { data }
   }
+
+  @ApiOperation({
+    summary: 'Get a webhook subscription',
+    description: 'One subscription with its delivery counters.',
+  })
+  @ApiParam(WEBHOOK_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The subscription.',
+    type: WebhookResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(WEBHOOK_NOT_FOUND_RESPONSE)
   @Get(':webhookId')
   @UseGuards(AuthGuard)
   async getWebhook(@Request() req, @Param('webhookId') webhookId: string) {
@@ -66,6 +189,22 @@ export class WebhookController {
     return { data }
   }
 
+  @ApiOperation({
+    summary: 'Create a webhook subscription',
+    description:
+      'textbee POSTs the events you pick to your delivery URL and signs each request with your signing secret, sent as the X-Signature header. Failed deliveries are retried up to 10 times, and a subscription that keeps failing is paused.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'The subscription was created.',
+    type: WebhookResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'The delivery URL is unusable, the signing secret is shorter than 20 characters, the event list is empty or unknown, or you already have the maximum number of subscriptions.',
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
   @Post()
   @UseGuards(AuthGuard)
   async createWebhook(
@@ -79,6 +218,24 @@ export class WebhookController {
     return { data }
   }
 
+  @ApiOperation({
+    summary: 'Update a webhook subscription',
+    description:
+      'Changes only the fields you send. Use isActive to re-enable a subscription textbee paused after repeated failures.',
+  })
+  @ApiParam(WEBHOOK_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The updated subscription.',
+    type: WebhookResponseDTO,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'The delivery URL is unusable, the signing secret is shorter than 20 characters, or the event list is empty or unknown.',
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(WEBHOOK_NOT_FOUND_RESPONSE)
   @Patch(':webhookId')
   @UseGuards(AuthGuard)
   async updateWebhook(
@@ -94,6 +251,19 @@ export class WebhookController {
     return { data }
   }
 
+  @ApiOperation({
+    summary: 'Delete a webhook subscription',
+    description:
+      'Stops all deliveries for this subscription. Its delivery history stays readable through GET /webhooks/notifications.',
+  })
+  @ApiParam(WEBHOOK_ID_PARAM)
+  @ApiResponse({
+    status: 200,
+    description: 'The subscription was deleted.',
+    type: WebhookDeletedResponseDTO,
+  })
+  @ApiResponse(UNAUTHORIZED_RESPONSE)
+  @ApiResponse(WEBHOOK_NOT_FOUND_RESPONSE)
   @Delete(':webhookId')
   @UseGuards(AuthGuard)
   async deleteWebhook(

--- a/api/src/webhook/webhook.dto.ts
+++ b/api/src/webhook/webhook.dto.ts
@@ -186,7 +186,10 @@ export class WebhookListResponseDTO {
 }
 
 export class WebhookResponseDTO {
-  @ApiProperty({ type: WebhookSubscriptionDTO })
+  @ApiProperty({
+    type: WebhookSubscriptionDTO,
+    description: 'The subscription.',
+  })
   data: WebhookSubscriptionDTO
 }
 
@@ -196,7 +199,10 @@ export class WebhookDeletedResultDTO {
 }
 
 export class WebhookDeletedResponseDTO {
-  @ApiProperty({ type: WebhookDeletedResultDTO })
+  @ApiProperty({
+    type: WebhookDeletedResultDTO,
+    description: 'Outcome of the delete.',
+  })
   data: WebhookDeletedResultDTO
 }
 
@@ -310,6 +316,9 @@ export class WebhookNotificationPageDTO {
 }
 
 export class WebhookNotificationListResponseDTO {
-  @ApiProperty({ type: WebhookNotificationPageDTO })
+  @ApiProperty({
+    type: WebhookNotificationPageDTO,
+    description: 'Delivery records with pagination.',
+  })
   data: WebhookNotificationPageDTO
 }

--- a/api/src/webhook/webhook.dto.ts
+++ b/api/src/webhook/webhook.dto.ts
@@ -1,16 +1,315 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { PaginationMetaDTO } from '../gateway/gateway.dto'
 import { WebhookEvent } from './webhook-event.enum'
 
 export class CreateWebhookDto {
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Label shown in the dashboard. Up to 64 characters.',
+    example: 'Order notifications',
+  })
   name?: string
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description:
+      'URL textbee POSTs events to. Must be http or https and publicly reachable. Private and loopback hosts are rejected.',
+    example: 'https://example.com/textbee/webhook',
+  })
   deliveryUrl: string
+
+  @ApiProperty({
+    type: String,
+    required: true,
+    description:
+      'Shared secret, at least 20 characters. textbee signs every delivery with it and sends the signature in the X-Signature header, so your endpoint can verify the request really came from textbee.',
+  })
   signingSecret?: string
+
+  @ApiProperty({
+    required: true,
+    isArray: true,
+    enum: WebhookEvent,
+    description: 'Events to deliver. At least one is required.',
+    example: [WebhookEvent.MESSAGE_RECEIVED],
+  })
   events: WebhookEvent[]
 }
 
 export class UpdateWebhookDto {
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Label shown in the dashboard. Up to 64 characters.',
+    example: 'Order notifications',
+  })
   name?: string
+
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description:
+      'Whether deliveries are attempted. Set it to true to re-enable a subscription textbee paused after repeated failures.',
+  })
   isActive: boolean
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      'New delivery URL. Same rules as on create: http or https, no private or loopback hosts.',
+    example: 'https://example.com/textbee/webhook',
+  })
   deliveryUrl: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'New signing secret, at least 20 characters.',
+  })
   signingSecret: string
+
+  @ApiProperty({
+    required: false,
+    isArray: true,
+    enum: WebhookEvent,
+    description: 'Replacement event list. Cannot be empty.',
+    example: [WebhookEvent.MESSAGE_RECEIVED, WebhookEvent.MESSAGE_DELIVERED],
+  })
   events: WebhookEvent[]
+}
+
+export class WebhookNoteDTO {
+  @ApiProperty({ type: Date, description: 'When the note was added.' })
+  at: Date
+
+  @ApiProperty({
+    type: String,
+    description:
+      'What textbee recorded, for example why the subscription was paused.',
+  })
+  text: string
+}
+
+export class WebhookSubscriptionDTO {
+  @ApiProperty({ type: String, description: 'Subscription id.' })
+  _id: string
+
+  @ApiProperty({ type: String, description: 'Owner account id.' })
+  user: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Label shown in the dashboard.',
+  })
+  name?: string
+
+  @ApiProperty({
+    type: Boolean,
+    description:
+      'Whether deliveries are attempted. textbee pauses subscriptions that keep failing.',
+  })
+  isActive: boolean
+
+  @ApiProperty({
+    isArray: true,
+    enum: WebhookEvent,
+    description: 'Events this subscription receives.',
+  })
+  events: string[]
+
+  @ApiProperty({ type: String, description: 'URL events are POSTed to.' })
+  deliveryUrl: string
+
+  @ApiProperty({
+    type: String,
+    description: 'Secret used to sign deliveries.',
+  })
+  signingSecret: string
+
+  @ApiProperty({ type: Number, description: 'Deliveries that succeeded.' })
+  successfulDeliveryCount: number
+
+  @ApiProperty({ type: Number, description: 'Deliveries that failed.' })
+  deliveryFailureCount: number
+
+  @ApiProperty({
+    type: Number,
+    description: 'Delivery attempts made, retries included.',
+  })
+  deliveryAttemptCount: number
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'Last time a delivery was attempted.',
+  })
+  lastDeliveryAttemptAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'Last time a delivery succeeded.',
+  })
+  lastDeliverySuccessAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'Last time a delivery failed.',
+  })
+  lastDeliveryFailureAt?: Date
+
+  @ApiProperty({
+    type: [WebhookNoteDTO],
+    required: false,
+    description: 'Notes textbee added, such as an auto-pause reason.',
+  })
+  notes?: WebhookNoteDTO[]
+
+  @ApiProperty({ type: Date, description: 'When the subscription was created.' })
+  createdAt: Date
+
+  @ApiProperty({ type: Date, description: 'When it was last updated.' })
+  updatedAt: Date
+}
+
+export class WebhookListResponseDTO {
+  @ApiProperty({
+    type: [WebhookSubscriptionDTO],
+    description: 'Your webhook subscriptions. Deleted ones are not returned.',
+  })
+  data: WebhookSubscriptionDTO[]
+}
+
+export class WebhookResponseDTO {
+  @ApiProperty({ type: WebhookSubscriptionDTO })
+  data: WebhookSubscriptionDTO
+}
+
+export class WebhookDeletedResultDTO {
+  @ApiProperty({ type: Boolean, description: 'Whether the delete succeeded.' })
+  success: boolean
+}
+
+export class WebhookDeletedResponseDTO {
+  @ApiProperty({ type: WebhookDeletedResultDTO })
+  data: WebhookDeletedResultDTO
+}
+
+export class WebhookNotificationDTO {
+  @ApiProperty({ type: String, description: 'Delivery record id.' })
+  _id: string
+
+  @ApiProperty({ type: String, description: 'Subscription this belongs to.' })
+  webhookSubscription: string
+
+  @ApiProperty({ enum: WebhookEvent, description: 'Event that was delivered.' })
+  event: string
+
+  @ApiProperty({
+    type: Object,
+    description: 'Exact JSON body textbee POSTed to your endpoint.',
+  })
+  payload: object
+
+  @ApiProperty({
+    type: String,
+    enum: ['pending', 'retrying', 'delivered', 'failed'],
+    description:
+      'Delivery state. Retrying means textbee will try again, failed means it gave up after 10 attempts.',
+  })
+  computedStatus: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'URL the delivery was sent to when it was attempted.',
+  })
+  deliveryUrl?: string
+
+  @ApiProperty({
+    type: Number,
+    description: 'Attempts made for this event.',
+  })
+  deliveryAttemptCount: number
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When your endpoint accepted the delivery.',
+  })
+  deliveredAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When the last attempt was made.',
+  })
+  lastDeliveryAttemptAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When the next retry is due.',
+  })
+  nextDeliveryAttemptAt?: Date
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description: 'When textbee stopped retrying.',
+  })
+  deliveryAttemptAbortedAt?: Date
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    enum: ['retryable', 'non-retryable'],
+    description: 'Whether the failure is worth retrying.',
+  })
+  errorType?: string
+
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description: 'Status code your endpoint returned on the last attempt.',
+  })
+  httpStatusCode?: number
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'First 1000 characters of your endpoint response.',
+  })
+  responseBody?: string
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: 'Idempotency key sent with the delivery.',
+  })
+  idempotencyKey?: string
+
+  @ApiProperty({ type: Date, description: 'When the event was recorded.' })
+  createdAt: Date
+}
+
+export class WebhookNotificationPageDTO {
+  @ApiProperty({
+    type: [WebhookNotificationDTO],
+    description: 'Delivery records, newest first.',
+  })
+  data: WebhookNotificationDTO[]
+
+  @ApiProperty({ type: PaginationMetaDTO, description: 'Pagination info.' })
+  meta: PaginationMetaDTO
+}
+
+export class WebhookNotificationListResponseDTO {
+  @ApiProperty({ type: WebhookNotificationPageDTO })
+  data: WebhookNotificationPageDTO
 }


### PR DESCRIPTION
Two related changes. The docs pass came first, because the spec is generated from the decorators and half of what it would have exported was undocumented.

## The spec

`pnpm run export:openapi` boots the app with `preview: true`, reads the controller decorators, filters to an allowlist, and writes `api/openapi.json`. Preview mode instantiates no providers, so this runs with no Mongo, no Redis, and no env file, which is also how it runs in CI. The runtime Swagger UI is untouched and still serves everything.

Filtering is an explicit list of (method, path) pairs in `src/openapi/public-operations.ts` rather than a tag filter, so a new endpoint stays out of the public spec until someone adds it deliberately. Fourteen operations: account-level send and bulk send, device reads, message history, single message and batch lookups, stats, and webhook CRUD plus delivery history. The deprecated device-scoped send routes, the device app contract (pairing, heartbeat, receive-sms, status updates), and everything the dashboard owns stay out. Generation throws if an allowlisted route disappears or if anything deprecated survives the filter.

The public document uses the title `textbee API`, sets `servers: [https://api.textbee.dev]`, and keeps `x-api-key` as its only security scheme, since the bearer flow is a dashboard session no API consumer can obtain. Schemas that only the removed operations referenced are pruned.

`src/openapi/build-public-document.spec.ts` regenerates the document and fails if it differs from the committed file, if the operation set changes, if anything is deprecated, if an operation has no summary, or if a request body resolves to a schema with no fields. The last two are what stop the problem below from creeping back.

## The docs pass

The webhook routes carried no swagger decorators at all and both webhook DTOs had no `@ApiProperty`, so those six operations would have exported with empty summaries and `{}` request bodies. Auth summaries were bare labels (`Login`, `Generate Api Key`). No controller documented a response schema and no path param was described anywhere.

All 50 endpoints now have a summary and a description, every path and query param is documented with its defaults and caps, and every operation has response schemas. Six request bodies that were typed inline, like `@Body() body: { message: string; turnstileToken: string }`, are DTOs now, since an inline type renders as no schema at all.

Documented status codes come from what the guards and services actually throw. The send routes return 429 when a plan limit is reached, for example, not 402.

Two schema corrections along the way. `DeviceDTO` described six fields of a thirty field document and advertised a `manufacturer` field that message queries do not populate, so it split into a full `DeviceDTO` and a small `MessageDeviceDTO` for the embedded summary. `RetrieveSMSDTO` described received messages only, although the endpoint returns both directions, so it now carries direction, status, and the delivery timestamps.

The Polar callback is excluded from the docs (a signed provider to server request, not a developer endpoint), as is the users controller, which has no routes and was showing up as an empty tag.

## Checks

- exporter with `MONGO_URI` and `REDIS_URL` unset writes 14 operations and exits clean
- `@apidevtools/swagger-cli validate` and `@redocly/cli lint` both pass with no warnings
- full test suite green, 293 tests
- the documented paths answer 401 against the live API and a made up path answers 404, so the server URL and the `/api/v1` prefix line up

The generated file also lands in textbee-marketing so it is served at textbee.dev/openapi.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a complete OpenAPI 3.0 reference for authenticated gateway, messaging, device, billing, support, and webhook endpoints.
  - Documented request and response formats, validation rules, authentication, pagination, errors, delivery statuses, and deprecations.
  - Added detailed examples and descriptions for API operations and data fields.
  - Added a generated public API specification that can be exported for integration and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->