### PR TITLE
Report the real message direction casing and stop the dashboard dropping it

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -231,7 +231,7 @@
             "name": "type",
             "required": false,
             "in": "query",
-            "description": "Direction to return. Default all.",
+            "description": "Direction to return, lowercase. Default all. Note the asymmetry: this filter is lowercase while the type field on each message comes back uppercase, and an unrecognised value such as SENT applies no filter at all rather than failing.",
             "schema": {
               "enum": [
                 "all",
@@ -1504,13 +1504,14 @@
           "type": {
             "type": "string",
             "enum": [
-              "sent",
-              "received"
+              "SENT",
+              "RECEIVED"
             ],
-            "description": "Direction of the message."
+            "description": "Direction of the message. Uppercase here, unlike the lowercase type filter on the message history query."
           },
           "status": {
             "type": "string",
+            "nullable": true,
             "enum": [
               "pending",
               "dispatched",
@@ -1520,7 +1521,7 @@
               "unknown",
               "received"
             ],
-            "description": "Delivery state. Incoming messages are always received. Outgoing messages move from pending to sent, then to delivered when the carrier confirms."
+            "description": "Delivery state, lowercase. Incoming messages are always received. Outgoing messages move from pending to sent, then to delivered when the carrier confirms. Absent on messages stored before status tracking, so treat a missing value as unknown."
           },
           "sender": {
             "type": "string",
@@ -1595,7 +1596,6 @@
           "_id",
           "device",
           "type",
-          "status",
           "createdAt",
           "updatedAt"
         ]
@@ -1705,15 +1705,18 @@
           },
           "status": {
             "type": "string",
+            "nullable": true,
             "enum": [
               "pending",
               "processing",
               "completed",
               "partial_success",
               "failed",
-              "unknown"
+              "unknown",
+              "sent",
+              "delivered"
             ],
-            "description": "Progress of the batch as a whole."
+            "description": "Progress of the batch as a whole, lowercase. Absent on batches stored before status tracking. sent and delivered appear on older batches that mirrored the per-message state."
           },
           "error": {
             "type": "string",
@@ -1741,7 +1744,6 @@
           "recipientCount",
           "successCount",
           "failureCount",
-          "status",
           "createdAt",
           "updatedAt"
         ]

--- a/api/src/app.module.tsbkp
+++ b/api/src/app.module.tsbkp
@@ -1,0 +1,123 @@
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  RequestMethod,
+} from '@nestjs/common'
+import { MongooseModule } from '@nestjs/mongoose'
+import { GatewayModule } from './gateway/gateway.module'
+import { AuthModule } from './auth/auth.module'
+import { UsersModule } from './users/users.module'
+import { ThrottlerModule } from '@nestjs/throttler'
+import { APP_GUARD } from '@nestjs/core/constants'
+import { WebhookModule } from './webhook/webhook.module'
+import { ThrottlerByIpGuard } from './auth/guards/throttle-by-ip.guard'
+import { Injectable, NestMiddleware } from '@nestjs/common'
+import { Request, Response, NextFunction } from 'express'
+import { ScheduleModule } from '@nestjs/schedule'
+import { BillingModule } from './billing/billing.module'
+import { SupportModule } from './support/support.module'
+import { BlogModule } from './blog/blog.module'
+import { ConfigModule, ConfigService } from '@nestjs/config'
+import { BullModule } from '@nestjs/bull'
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    console.log(`req:`, {
+      // headers: req.headers,
+      body: req.body,
+      originalUrl: req.originalUrl,
+    })
+
+    try {
+      const blockList = [
+        '66e75e8ee704cf23bfca1be9',
+        'your tax refund has been processed',
+        'mygov-tax.netlify.app',
+        '66e87554e704cf23bfca5a66',
+        'mygovau:',
+        'you have a pending income tax notice',
+        'kv.ci/8H7stz',
+
+        '667254b13d552f16138406bc',
+        'www.trueverify.org',
+
+        '66d2cdbf3d552f1613cecdb3',
+        'neteller.help/Reset/infirstFCU',
+
+        '66c251f93d552f1613b0a5f2',
+        '66c24bcd3d552f1613b092cc',
+        'netfilxonlineinfo.com',
+      ]
+
+      // if originalUrl contains any of the blockList items, block the request
+      if (blockList.some((item) => req.originalUrl.includes(item))) {
+        console.log('Blocked request as it contains blockList item in the URL')
+        res.status(500).send('Sorry, Something went wrong')
+        return
+      }
+
+      // parse the reqest body to string and check if it contains any of the blockList items
+      const body = JSON.stringify(req.body)?.toLowerCase()
+      if (blockList.some((item) => body.includes(item))) {
+        console.log('Blocked request as it contains blockList item in the body')
+        res.status(500).send('Sorry, Something went wrong')
+        return
+      }
+    } catch (error) {
+      console.log('Error in LoggerMiddleware:')
+      console.log(error)
+    }
+
+    if (next) {
+      next()
+    }
+  }
+}
+
+@Module({
+  imports: [
+    MongooseModule.forRoot(process.env.MONGO_URI),
+    ConfigModule.forRoot({
+      isGlobal: true,
+    }),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000,
+        limit: 60,
+      },
+    ]),
+    ScheduleModule.forRoot(),
+    BullModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => {
+        return {
+          redis: configService.get('REDIS_URL'),
+        }
+      },
+    }),
+    AuthModule,
+    UsersModule,
+    GatewayModule,
+    WebhookModule,
+    BillingModule,
+    SupportModule,
+    BlogModule,
+  ],
+  controllers: [],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerByIpGuard,
+    },
+  ],
+})
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(LoggerMiddleware)
+      .forRoutes({ path: '*', method: RequestMethod.ALL })
+  }
+}

--- a/api/src/gateway/gateway.controller.ts
+++ b/api/src/gateway/gateway.controller.ts
@@ -523,7 +523,8 @@ export class GatewayController {
     required: false,
     type: String,
     enum: ['all', 'sent', 'received'],
-    description: 'Direction to return. Default all.',
+    description:
+      'Direction to return, lowercase. Default all. Note the asymmetry: this filter is lowercase while the type field on each message comes back uppercase, and an unrecognised value such as SENT applies no filter at all rather than failing.',
   })
   @ApiQuery({
     name: 'search',

--- a/api/src/gateway/gateway.dto.ts
+++ b/api/src/gateway/gateway.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger'
+import { SMSType } from './sms-type.enum'
 
 export class SimInfoDTO {
   @ApiProperty({
@@ -802,14 +803,16 @@ export class RetrieveSMSDTO {
   device: MessageDeviceDTO
 
   @ApiProperty({
-    type: String,
-    enum: ['sent', 'received'],
-    description: 'Direction of the message.',
+    enum: SMSType,
+    description:
+      'Direction of the message. Uppercase here, unlike the lowercase type filter on the message history query.',
   })
   type: string
 
   @ApiProperty({
     type: String,
+    required: false,
+    nullable: true,
     enum: [
       'pending',
       'dispatched',
@@ -820,9 +823,9 @@ export class RetrieveSMSDTO {
       'received',
     ],
     description:
-      'Delivery state. Incoming messages are always received. Outgoing messages move from pending to sent, then to delivered when the carrier confirms.',
+      'Delivery state, lowercase. Incoming messages are always received. Outgoing messages move from pending to sent, then to delivered when the carrier confirms. Absent on messages stored before status tracking, so treat a missing value as unknown.',
   })
-  status: string
+  status?: string
 
   @ApiProperty({
     type: String,
@@ -1336,6 +1339,8 @@ export class SMSBatchDTO {
 
   @ApiProperty({
     type: String,
+    required: false,
+    nullable: true,
     enum: [
       'pending',
       'processing',
@@ -1343,10 +1348,13 @@ export class SMSBatchDTO {
       'partial_success',
       'failed',
       'unknown',
+      'sent',
+      'delivered',
     ],
-    description: 'Progress of the batch as a whole.',
+    description:
+      'Progress of the batch as a whole, lowercase. Absent on batches stored before status tracking. sent and delivered appear on older batches that mirrored the per-message state.',
   })
-  status: string
+  status?: string
 
   @ApiProperty({
     type: String,

--- a/api/src/openapi/build-public-document.spec.ts
+++ b/api/src/openapi/build-public-document.spec.ts
@@ -7,6 +7,7 @@ import {
 } from './build-public-document'
 import { PUBLIC_OPERATION_KEYS, toOperationKey } from './public-operations'
 import { API_KEY_SECURITY_SCHEME } from './swagger-config'
+import { SMSType } from '../gateway/sms-type.enum'
 
 const COMMITTED_SPEC_PATH = join(__dirname, '..', '..', 'openapi.json')
 const REGENERATE_HINT = 'Run `pnpm run export:openapi` and commit openapi.json.'
@@ -72,6 +73,15 @@ describe('public openapi document', () => {
       .map(([key]) => key)
 
     expect(empty).toEqual([])
+  })
+
+  // The wire format is uppercase and the query filter that selects it is
+  // lowercase, so a hand-written enum here drifts silently and teaches every
+  // consumer a comparison that never matches.
+  it('documents the message direction with the values the API really sends', () => {
+    expect(
+      document.components.schemas['RetrieveSMSDTO']['properties'].type.enum,
+    ).toEqual(Object.values(SMSType))
   })
 
   // A mismatch means a decorator changed without the spec being regenerated.

--- a/web/app/(app)/dashboard/(components)/message-history/group.test.ts
+++ b/web/app/(app)/dashboard/(components)/message-history/group.test.ts
@@ -14,14 +14,22 @@ const at = (daysAgo: number, hour = 12) => {
 }
 
 describe('messageDirection', () => {
+  // The API sends SENT and RECEIVED uppercase. These fixtures used to be
+  // lowercase, which no row ever is, so every case silently exercised the
+  // fallback instead of the type it claimed to test.
   it('uses the type the API returns', () => {
-    expect(messageDirection(msg({ type: 'received' }))).toBe('received')
-    expect(messageDirection(msg({ type: 'sent' }))).toBe('sent')
+    expect(messageDirection(msg({ type: 'RECEIVED' }))).toBe('received')
+    expect(messageDirection(msg({ type: 'SENT' }))).toBe('sent')
   })
 
   it('trusts type over the presence of a sender', () => {
     // A sent row that happens to carry a sender must not flip to received.
-    expect(messageDirection(msg({ type: 'sent', sender: '+1415' }))).toBe('sent')
+    expect(messageDirection(msg({ type: 'SENT', sender: '+1415' }))).toBe('sent')
+  })
+
+  it('accepts either casing, so a normalized payload still works', () => {
+    expect(messageDirection(msg({ type: 'sent' as never }))).toBe('sent')
+    expect(messageDirection(msg({ type: 'received' as never }))).toBe('received')
   })
 
   it('falls back to the sender check for rows written before type existed', () => {

--- a/web/app/(app)/dashboard/(components)/message-history/group.ts
+++ b/web/app/(app)/dashboard/(components)/message-history/group.ts
@@ -23,9 +23,15 @@ export function messageDate(message: SmsMessage): Date | null {
  * Prefer the `type` the API returns. The previous code inferred direction from
  * whether `sender` was present, which is only a proxy, so that check is kept
  * as a fallback for rows written before `type` existed.
+ *
+ * The API sends SENT and RECEIVED uppercase, so this compares case-insensitively.
+ * Matching the lowercase spelling alone never hit, which quietly left every
+ * message on the fallback.
  */
 export function messageDirection(message: SmsMessage): 'sent' | 'received' {
-  if (message.type === 'sent' || message.type === 'received') return message.type
+  const type = message.type?.toLowerCase()
+  if (type === 'sent') return 'sent'
+  if (type === 'received') return 'received'
   return message.sender ? 'received' : 'sent'
 }
 

--- a/web/app/(app)/dashboard/(components)/message-history/types.ts
+++ b/web/app/(app)/dashboard/(components)/message-history/types.ts
@@ -6,9 +6,9 @@ export type SmsMessage = {
   _id: string
   message?: string
   status?: string
-  // Direction as recorded by the API (SMSType). Optional because rows written
-  // before it existed do not carry it.
-  type?: 'sent' | 'received'
+  // Direction as recorded by the API (SMSType), which sends it uppercase.
+  // Optional because rows written before it existed do not carry it.
+  type?: 'SENT' | 'RECEIVED'
   sender?: string
   recipient?: string
   recipients?: string[]


### PR DESCRIPTION
`SMSType.SENT` is `'SENT'`, written at six call sites, stored as a bare string, never normalized on read. Two places assumed lowercase.

## The dashboard was running on its fallback

`messageDirection` prefers the `type` the API returns and keeps a `sender` heuristic for rows written before `type` existed. The comparison was against `'sent'` and `'received'`, so it never matched anything the API sends, and every message took the legacy path instead.

That is mostly invisible, because sender presence usually agrees with direction. It disagrees for a sent message that carries a sender, which is the exact case the `type` preference was added to handle, and there it answered `received`.

The tests did not catch it because every fixture used a casing the API never emits. Reverting the fix now fails two of them, which is the point.

## The exported spec taught the same mistake

`openapi.json` declared `enum: ["sent","received"]`. That file is what GPT Actions, the API reference route, and llms-full.txt read, so it would have taught every model a comparison that silently never matches. The enum now comes from `SMSType` directly rather than being retyped by hand, and a test asserts the two stay equal.

There is a real asymmetry underneath, and both sides now say so: the message history filter is lowercase, the `type` field on each message is uppercase, and an unrecognised filter value such as `SENT` applies no filter at all rather than failing, so it quietly returns both directions.

## Two schemas that misdescribed stored data

Checking the collection before picking a fix turned these up:

- `status` on both messages and batches is absent on rows predating status tracking, but the spec declared it required with a strict enum. A consumer validating responses against that would reject a real message.
- The batch status enum was missing two values that older batches use.

Both are now optional and nullable, and the batch enum is complete.

## Not changed

The wire format. Uppercase has been the only value since April 2024, and normalizing it would break anyone already matching `SENT`.

## Checks

- api: 7 openapi tests including the new enum guard, spec lints clean under redocly
- web: 206 tests across 28 files, typecheck clean
- the two new direction tests fail without the fix, pass with it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message history handling for uppercase `SENT` and `RECEIVED` message types.
  * Preserved compatibility with lowercase message data and sender-based direction detection.
  * Improved handling of missing or legacy message and batch statuses.

* **Documentation**
  * Clarified message direction filters, response values, unrecognized filters, and legacy status values in the API documentation.
  * Updated public API schemas to accurately mark status fields as optional and nullable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->