### PR TITLE
Filter account message history by batch id

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -300,6 +300,15 @@
             }
           },
           {
+            "name": "smsBatchId",
+            "required": false,
+            "in": "query",
+            "description": "Only messages from this batch, using the smsBatchId returned by a send. Combine with status=failed to list the recipients of a batch that failed.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "type",
             "required": false,
             "in": "query",
@@ -350,13 +359,13 @@
             }
           },
           "400": {
-            "description": "Invalid deviceIds, direction, status, from, to, order, or cursor value. Unknown filter values fail rather than silently applying no filter."
+            "description": "Invalid deviceIds, smsBatchId, direction, status, from, to, order, or cursor value. Unknown filter values fail rather than silently applying no filter."
           },
           "401": {
             "description": "Missing, invalid, or revoked API key."
           },
           "404": {
-            "description": "No device with that id on your account."
+            "description": "A deviceIds entry or the smsBatchId is not on your account."
           }
         },
         "security": [

--- a/api/src/gateway/gateway.controller.ts
+++ b/api/src/gateway/gateway.controller.ts
@@ -441,10 +441,13 @@ export class GatewayController {
   @ApiResponse({
     status: 400,
     description:
-      'Invalid deviceIds, direction, status, from, to, order, or cursor value. Unknown filter values fail rather than silently applying no filter.',
+      'Invalid deviceIds, smsBatchId, direction, status, from, to, order, or cursor value. Unknown filter values fail rather than silently applying no filter.',
   })
   @ApiResponse(UNAUTHORIZED_RESPONSE)
-  @ApiResponse(DEVICE_NOT_FOUND_RESPONSE)
+  @ApiResponse({
+    status: 404,
+    description: 'A deviceIds entry or the smsBatchId is not on your account.',
+  })
   @ApiQuery({
     name: 'deviceIds',
     required: false,
@@ -467,6 +470,13 @@ export class GatewayController {
     type: String,
     enum: ['all', 'sent', 'received'],
     description: 'Deprecated alias of direction. Still works; prefer direction.',
+  })
+  @ApiQuery({
+    name: 'smsBatchId',
+    required: false,
+    type: String,
+    description:
+      'Only messages from this batch, using the smsBatchId returned by a send. Combine with status=failed to list the recipients of a batch that failed.',
   })
   @ApiQuery({
     name: 'status',

--- a/api/src/gateway/gateway.service.spec.ts
+++ b/api/src/gateway/gateway.service.spec.ts
@@ -1597,6 +1597,68 @@ describe('GatewayService', () => {
       expect(first.data.length + rest.length).toBe(13)
     })
 
+    it('filters by an owned smsBatchId and composes with status', async () => {
+      const batchId = new Types.ObjectId()
+      mockSmsBatchModel.findOne.mockResolvedValue({ _id: batchId, user: userId })
+      store.push(
+        { _id: new Types.ObjectId(), user: userId, device: deviceA, smsBatch: batchId, type: SMSType.SENT, status: 'failed', createdAt: new Date() },
+        { _id: new Types.ObjectId(), user: userId, device: deviceA, smsBatch: batchId, type: SMSType.SENT, status: 'delivered', createdAt: new Date() },
+        { _id: new Types.ObjectId(), user: userId, device: deviceA, type: SMSType.SENT, status: 'failed', createdAt: new Date() },
+      )
+
+      const result = await service.getMessagesForUser(
+        user,
+        { order: 'desc', smsBatchId: batchId, status: 'failed' } as any,
+        1,
+        50,
+      )
+
+      expect(result.data).toHaveLength(1)
+      expect(String(result.data[0].smsBatch)).toBe(String(batchId))
+      expect(result.data[0].status).toBe('failed')
+    })
+
+    it('404s on an smsBatchId owned by another user, naming it', async () => {
+      const batchId = new Types.ObjectId()
+      mockSmsBatchModel.findOne.mockResolvedValue({ _id: batchId, user: new Types.ObjectId() })
+
+      const caught = await service
+        .getMessagesForUser(user, { order: 'desc', smsBatchId: batchId } as any, 1, 50)
+        .then(() => undefined)
+        .catch((e) => e)
+      expect(caught).toBeInstanceOf(HttpException)
+      expect((caught as HttpException).getStatus()).toBe(404)
+      expect(((caught as HttpException).getResponse() as any).error).toContain(String(batchId))
+    })
+
+    it('404s on an smsBatchId that does not exist', async () => {
+      mockSmsBatchModel.findOne.mockResolvedValue(null)
+      const caught = await service
+        .getMessagesForUser(user, { order: 'desc', smsBatchId: new Types.ObjectId() } as any, 1, 50)
+        .then(() => undefined)
+        .catch((e) => e)
+      expect((caught as HttpException).getStatus()).toBe(404)
+    })
+
+    it('lets a legacy user-less batch through, still scoped by live devices', async () => {
+      const batchId = new Types.ObjectId()
+      // Pre-backfill batches lack user; the device $in is what protects them
+      mockSmsBatchModel.findOne.mockResolvedValue({ _id: batchId })
+      store.push(
+        { _id: new Types.ObjectId(), user: userId, device: deviceA, smsBatch: batchId, type: SMSType.SENT, status: 'sent', createdAt: new Date() },
+        { _id: new Types.ObjectId(), user: new Types.ObjectId(), device: deletedDevice, smsBatch: batchId, type: SMSType.SENT, status: 'sent', createdAt: new Date() },
+      )
+
+      const result = await service.getMessagesForUser(
+        user,
+        { order: 'desc', smsBatchId: batchId } as any,
+        1,
+        50,
+      )
+      expect(result.data).toHaveLength(1)
+      expect(String(result.data[0].device)).toBe(String(deviceA))
+    })
+
     it('maps direction to the stored type and decorates responses with lowercase direction', async () => {
       seed(deviceA, 1, new Date('2026-08-01T00:00:00Z'), false, SMSType.SENT)
       seed(deviceA, 1, new Date('2026-08-02T00:00:00Z'), false, SMSType.RECEIVED)

--- a/api/src/gateway/gateway.service.ts
+++ b/api/src/gateway/gateway.service.ts
@@ -1196,6 +1196,22 @@ export class GatewayService {
       user: user._id,
       device: { $in: scopedDeviceIds },
     }
+    if (filters.smsBatchId) {
+      // 404 on an unowned batch, matching the deviceIds contract. A legacy
+      // batch without a user field falls through; the device $in above still
+      // scopes what its filter can return.
+      const batch = await this.smsBatchModel.findOne(
+        { _id: filters.smsBatchId },
+        'user',
+      )
+      if (!batch || (batch.user && String(batch.user) !== String(user._id))) {
+        throw new HttpException(
+          { error: `Batch not found: ${filters.smsBatchId}` },
+          HttpStatus.NOT_FOUND,
+        )
+      }
+      query.smsBatch = filters.smsBatchId
+    }
     if (filters.direction) {
       query.type = toStoredType(filters.direction)
     }

--- a/api/src/gateway/message-query.spec.ts
+++ b/api/src/gateway/message-query.spec.ts
@@ -84,6 +84,24 @@ describe('parseMessageQuery', () => {
     })
   })
 
+  describe('smsBatchId', () => {
+    it('parses a valid id and treats empty as absent', () => {
+      const batchId = new Types.ObjectId().toHexString()
+      expect(parseMessageQuery({ smsBatchId: batchId }).smsBatchId?.toString()).toBe(batchId)
+      expect(parseMessageQuery({ smsBatchId: '' }).smsBatchId).toBeUndefined()
+      expect(parseMessageQuery({}).smsBatchId).toBeUndefined()
+    })
+
+    it('400s on a malformed id, naming it', () => {
+      expect400(() => parseMessageQuery({ smsBatchId: 'not-an-id' }), /not-an-id/)
+    })
+
+    it('400s (not 500s) on a repeated key', () => {
+      const batchId = new Types.ObjectId().toHexString()
+      expect(() => parseMessageQuery({ smsBatchId: [batchId, batchId] })).toThrow(HttpException)
+    })
+  })
+
   describe('direction and the deprecated type alias', () => {
     it('is case-insensitive', () => {
       for (const v of ['sent', 'SENT', 'Sent']) {

--- a/api/src/gateway/message-query.ts
+++ b/api/src/gateway/message-query.ts
@@ -28,6 +28,7 @@ const DATETIME_WITH_OFFSET =
 
 export interface ParsedMessageQuery {
   deviceIds?: Types.ObjectId[]
+  smsBatchId?: Types.ObjectId
   direction?: MessageDirection
   status?: MessageStatus
   search?: string
@@ -112,6 +113,16 @@ export function parseMessageQuery(query: Record<string, unknown>): ParsedMessage
   const deviceIds = parseDeviceIds(query.deviceIds)
   const direction = parseDirection(query)
 
+  const smsBatchIdRaw = asSingleString(query.smsBatchId, 'smsBatchId')
+  let smsBatchId: Types.ObjectId | undefined
+  if (smsBatchIdRaw !== undefined && smsBatchIdRaw.trim() !== '') {
+    const trimmed = smsBatchIdRaw.trim()
+    if (!Types.ObjectId.isValid(trimmed)) {
+      badRequest(`Invalid smsBatchId '${smsBatchIdRaw}'`)
+    }
+    smsBatchId = new Types.ObjectId(trimmed)
+  }
+
   const statusRaw = asSingleString(query.status, 'status')
   let status: MessageStatus | undefined
   if (statusRaw !== undefined && statusRaw.trim() !== '') {
@@ -150,5 +161,5 @@ export function parseMessageQuery(query: Record<string, unknown>): ParsedMessage
     cursor = decodeCursor(cursorRaw.trim())
   }
 
-  return { deviceIds, direction, status, search, from, to, order, cursor }
+  return { deviceIds, smsBatchId, direction, status, search, from, to, order, cursor }
 }


### PR DESCRIPTION
Adds an optional `smsBatchId` query parameter to `GET /gateway/messages`.

Why: a deviceless send returns `smsBatchId`, but reading that batch back required `GET /gateway/devices/:id/sms-batch/:smsBatchId`, and a deviceless sender never had a device id to put there. This closes the loop, and it composes with the existing filters: `smsBatchId` + `status=failed` lists exactly the recipients of a campaign that failed.

Contract matches `deviceIds`: malformed id 400s, unowned or nonexistent batch 404s naming the id. Batches predating the `user` field stay readable and are scoped by the caller's live devices. The `smsBatch_1` index already covers the query.

Tests cover the filter, the status composition, both 404 cases, and the legacy-batch path. Spec regenerated; the marketing copy syncs after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)