### PR TITLE
fix(android): delete/edit correct SMS filter rule by resolving position at click time (#281)

### DIFF
--- a/android/app/src/main/java/com/vernu/sms/activities/SMSFilterActivity.java
+++ b/android/app/src/main/java/com/vernu/sms/activities/SMSFilterActivity.java
@@ -238,8 +238,14 @@ public class SMSFilterActivity extends AppCompatActivity {
             String caseText = rule.isCaseSensitive() ? " (Case Sensitive)" : " (Case Insensitive)";
             holder.filterTargetText.setText(filterTargetText + caseText);
 
-            holder.editButton.setOnClickListener(v -> showAddEditRuleDialog(position));
-            holder.deleteButton.setOnClickListener(v -> deleteRule(position));
+            holder.editButton.setOnClickListener(v -> {
+                int pos = holder.getBindingAdapterPosition();
+                if (pos != RecyclerView.NO_POSITION) showAddEditRuleDialog(pos);
+            });
+            holder.deleteButton.setOnClickListener(v -> {
+                int pos = holder.getBindingAdapterPosition();
+                if (pos != RecyclerView.NO_POSITION) deleteRule(pos);
+            });
         }
 
         @Override


### PR DESCRIPTION
Fixes #281

## Problem
`FilterRulesAdapter.onBindViewHolder` captured the bind-time `position` inside the edit/delete click listeners. After a deletion, `notifyItemRemoved` does not rebind the rows below the removed one, so they keep a stale captured index. Tapping delete/edit on a shifted row then acts on the wrong rule, and once the list shrinks past that index `getRules().remove(position)` throws `IndexOutOfBoundsException` and crashes.

## Fix
Resolve the index live via `holder.getBindingAdapterPosition()` inside the click lambdas and bail on `RecyclerView.NO_POSITION`, for both the edit and delete buttons.

## Repro (before)
1. Create three rules
2. Delete the first
3. Tap delete on the row now at the top → wrong rule removed / crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editing and deleting SMS filters to target the correct item after list updates.
  * Ignored actions triggered from invalid or outdated list positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->