### PR TITLE
Refresh example phone numbers in docs and fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Messages go out through your default device, or otherwise the enabled device wit
 const API_KEY = 'YOUR_API_KEY';
  
 await axios.post('https://api.textbee.dev/api/v1/gateway/send-sms', {
-  recipients: [ '+251912345678' ],
+  recipients: [ '+12025550123' ],
   message: 'Hello World!',
 }, {
   headers: { 'x-api-key': API_KEY },
@@ -73,7 +73,7 @@ API_KEY = 'YOUR_API_KEY'
 requests.post(
     'https://api.textbee.dev/api/v1/gateway/send-sms',
     json={
-        'recipients': ['+251912345678'],
+        'recipients': ['+12025550123'],
         'message': 'Hello World!',
     },
     headers={'x-api-key': API_KEY},
@@ -88,7 +88,7 @@ curl -X POST "https://api.textbee.dev/api/v1/gateway/send-sms" \
   -H 'x-api-key: YOUR_API_KEY' \
   -H 'Content-Type: application/json' \
   -d '{
-    "recipients": [ "+251912345678" ],
+    "recipients": [ "+12025550123" ],
     "message": "Hello World!"
   }'
 ```

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1369,8 +1369,8 @@
           "recipients": {
             "description": "Phone numbers to send to, in international format. Each recipient is billed as one message.",
             "example": [
-              "+2519xxxxxxxx",
-              "+2517xxxxxxxx"
+              "+12025550123",
+              "+12025550124"
             ],
             "type": "array",
             "items": {
@@ -1396,8 +1396,8 @@
             "deprecated": true,
             "description": "Legacy alias for recipients. Used only when recipients is absent.",
             "example": [
-              "+2519xxxxxxxx",
-              "+2517xxxxxxxx"
+              "+12025550123",
+              "+12025550124"
             ],
             "type": "array",
             "items": {
@@ -1471,8 +1471,8 @@
           "recipients": {
             "description": "Phone numbers to send to, in international format. Each recipient is billed as one message.",
             "example": [
-              "+2519xxxxxxxx",
-              "+2517xxxxxxxx"
+              "+12025550123",
+              "+12025550124"
             ],
             "type": "array",
             "items": {
@@ -1498,8 +1498,8 @@
             "deprecated": true,
             "description": "Legacy alias for recipients. Used only when recipients is absent.",
             "example": [
-              "+2519xxxxxxxx",
-              "+2517xxxxxxxx"
+              "+12025550123",
+              "+12025550124"
             ],
             "type": "array",
             "items": {
@@ -1980,7 +1980,7 @@
           "recipientPreview": {
             "type": "string",
             "description": "Short preview of the recipient list.",
-            "example": "+2519xxxxxxxx and 3 others"
+            "example": "+12025550123 and 3 others"
           },
           "successCount": {
             "type": "number",

--- a/api/src/gateway/gateway.dto.ts
+++ b/api/src/gateway/gateway.dto.ts
@@ -267,7 +267,7 @@ export class SMSData {
     required: true,
     description:
       'Phone numbers to send to, in international format. Each recipient is billed as one message.',
-    example: ['+2519xxxxxxxx', '+2517xxxxxxxx'],
+    example: ['+12025550123', '+12025550124'],
   })
   recipients: string[]
 
@@ -311,7 +311,7 @@ export class SMSData {
     deprecated: true,
     description:
       'Legacy alias for recipients. Used only when recipients is absent.',
-    example: ['+2519xxxxxxxx', '+2517xxxxxxxx'],
+    example: ['+12025550123', '+12025550124'],
   })
   receivers: string[]
 }
@@ -1397,7 +1397,7 @@ export class SMSBatchDTO {
     type: String,
     required: false,
     description: 'Short preview of the recipient list.',
-    example: '+2519xxxxxxxx and 3 others',
+    example: '+12025550123 and 3 others',
   })
   recipientPreview?: string
 

--- a/web/e2e/message-history.spec.ts
+++ b/web/e2e/message-history.spec.ts
@@ -43,7 +43,7 @@ test.describe('message history (mocked API, no real backend)', () => {
           body: JSON.stringify({
             data: Array.from({ length: 12 }).map((_, i) => ({
               _id: `m${i}`,
-              sender: `+2519403617${40 + i}`,
+              sender: `+120255501${40 + i}`,
               message: 'A message long enough to wrap onto a second line here',
               status: 'received',
               type: 'received',
@@ -60,7 +60,7 @@ test.describe('message history (mocked API, no real backend)', () => {
       await page.evaluate(() => window.scrollTo(0, 420))
 
       const headers = await page.locator('h3').all()
-      const rows = await page.getByRole('button', { name: /\+2519/ }).all()
+      const rows = await page.getByRole('button', { name: /\+1202555/ }).all()
 
       for (const header of headers) {
         const hb = await header.boundingBox()
@@ -79,7 +79,7 @@ test.describe('message history (mocked API, no real backend)', () => {
 
       // A covering header also swallowed the row's click, so the row must
       // still be clickable after scrolling.
-      await page.getByRole('button', { name: /\+2519/ }).first().click()
+      await page.getByRole('button', { name: /\+1202555/ }).first().click()
       await expect(page.getByRole('dialog')).toBeVisible()
     })
   }
@@ -260,7 +260,7 @@ test.describe('message history (mocked API, no real backend)', () => {
             data: [
               {
                 _id: 'longurl_1',
-                recipient: '+251912657519',
+                recipient: '+12025550123',
                 message:
                   'Support request - textbee support\nUrgency: Urgent\nView conversation:\nhttps://dash.supporthq.app/dashboard/projects/69a591f28bdb2cda5452246b/conversations/69c2a0a058b1a815140a9be5',
                 status: 'failed',

--- a/web/lib/api/cache-invalidation.test.tsx
+++ b/web/lib/api/cache-invalidation.test.tsx
@@ -192,7 +192,7 @@ describe('cache invalidation', () => {
     act(() => {
       result.current.mutate({
         deviceId,
-        recipients: ['+251900000000'],
+        recipients: ['+12025550100'],
         message: 'hi',
       })
     })


### PR DESCRIPTION
Swaps the placeholder phone numbers used in the README, the API docs examples, and a couple of test fixtures for numbers from the reserved 555-01XX range, which is set aside for documentation and can never route to a real subscriber.

Covers:
- README quickstart snippets (JS, Python, curl)
- `recipients` and recipient-summary examples in the gateway DTOs, plus the regenerated `api/openapi.json`
- the message history e2e fixtures and the matching row selector
- one unit test fixture in the web app

No behavior changes. `api/openapi.json` was regenerated with `pnpm run export:openapi` rather than hand-edited, and the diff is limited to the example values. The affected web unit test passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SMS examples in the README and API documentation to use U.S. phone-number formats.

* **Tests**
  * Updated sample phone numbers in message-history and SMS-related test scenarios to match the revised examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->