### PR TITLE
Update GitHub repository URLs to the textbee org

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,14 +1,14 @@
 # These are supported funding model platforms
 
-github: [vernu] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: vernu
+# github: [vernu] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+# patreon: vernu
 # open_collective: textbee
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: textbee
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+# community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+# liberapay: # Replace with a single Liberapay username
+# issuehunt: # Replace with a single IssueHunt username
+# lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+# polar: textbee
 # buy_me_a_coffee: vernu
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![GitHub stars](https://img.shields.io/github/stars/vernu/textbee)
-![License](https://img.shields.io/github/license/vernu/textbee)
-![Release](https://img.shields.io/github/v/release/vernu/textbee)
+![GitHub stars](https://img.shields.io/github/stars/textbee/textbee)
+![License](https://img.shields.io/github/license/textbee/textbee)
+![Release](https://img.shields.io/github/v/release/textbee/textbee)
 [![Discord](https://img.shields.io/discord/1236287182940016723?label=Discord&logo=discord)](https://textbee.dev/discord)
 
 # textbee.dev - android sms gateway
@@ -243,14 +243,14 @@ See [textbee.dev](https://textbee.dev) for current plans and limits. You can alw
 
 Contributions are welcome!
 
-1. [Fork](https://github.com/vernu/textbee/fork) the project.
+1. [Fork](https://github.com/textbee/textbee/fork) the project.
 2. Create a feature or bugfix branch from `main` branch.
 3. Make sure your commit messages and PR comment summaries are descriptive.
 4. Create a pull request to the `main` branch.
 
 ## Bug Reporting and Feature Requests
 
-Please feel free to [create an issue](https://github.com/vernu/textbee/issues/new) in the repository for any bug reports or feature requests. Make sure to provide a detailed description of the issue or feature you are requesting and properly label whether it is a bug or a feature request.
+Please feel free to [create an issue](https://github.com/textbee/textbee/issues/new) in the repository for any bug reports or feature requests. Make sure to provide a detailed description of the issue or feature you are requesting and properly label whether it is a bug or a feature request.
 
 Please note that if you discover any vulnerability or security issue, we kindly request that you refrain from creating a public issue. Instead, send an email detailing the vulnerability to contact@textbee.dev.
 

--- a/android/app/src/main/java/com/vernu/sms/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/settings/SettingsScreen.kt
@@ -415,7 +415,7 @@ fun SettingsScreen(
                         }
                         OutlinedButton(
                             onClick = {
-                                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/vernu/textbee")))
+                                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/textbee/textbee")))
                             }
                         ) {
                             Text("GitHub")

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -839,7 +839,7 @@
     "contact": {},
     "license": {
       "name": "MIT",
-      "url": "https://github.com/vernu/textbee/blob/main/LICENSE"
+      "url": "https://github.com/textbee/textbee/blob/main/LICENSE"
     }
   },
   "tags": [

--- a/api/src/mail/templates/password-reset-request.hbs
+++ b/api/src/mail/templates/password-reset-request.hbs
@@ -101,7 +101,7 @@
             Join Discord
           </a>
           <a
-            href='https://github.com/vernu/textbee'
+            href='https://github.com/textbee/textbee'
             style='display: inline-block; margin: 0 10px; color: #333; text-decoration: none;'
           >
             <img
@@ -110,17 +110,6 @@
               style='width: 20px; vertical-align: middle;'
             />
             Star on GitHub
-          </a>
-          <a
-            href='https://patreon.com/vernu'
-            style='display: inline-block; margin: 0 10px; color: #FF424D; text-decoration: none;'
-          >
-            <img
-              src='https://c5.patreon.com/external/logo/downloads_logomark_color_on_white.png'
-              alt='Patreon'
-              style='width: 20px; vertical-align: middle;'
-            />
-            Support on Patreon
           </a>
         </div>
       </div>

--- a/api/src/mail/templates/password-reset-success.hbs
+++ b/api/src/mail/templates/password-reset-success.hbs
@@ -64,7 +64,7 @@
             Join Discord
           </a>
           <a
-            href='https://github.com/vernu/textbee'
+            href='https://github.com/textbee/textbee'
             style='display: inline-block; margin: 0 10px; color: #333; text-decoration: none;'
           >
             <img
@@ -73,17 +73,6 @@
               style='width: 20px; vertical-align: middle;'
             />
             Star on GitHub
-          </a>
-          <a
-            href='https://patreon.com/vernu'
-            style='display: inline-block; margin: 0 10px; color: #FF424D; text-decoration: none;'
-          >
-            <img
-              src='https://c5.patreon.com/external/logo/downloads_logomark_color_on_white.png'
-              alt='Patreon'
-              style='width: 20px; vertical-align: middle;'
-            />
-            Support on Patreon
           </a>
         </div>
       </div>

--- a/api/src/mail/templates/verify-email.hbs
+++ b/api/src/mail/templates/verify-email.hbs
@@ -87,7 +87,7 @@
             Join Discord
           </a>
           <a
-            href='https://github.com/vernu/textbee'
+            href='https://github.com/textbee/textbee'
             style='display: inline-block; margin: 0 10px; color: #333; text-decoration: none;'
           >
             <img
@@ -96,17 +96,6 @@
               style='width: 20px; vertical-align: middle;'
             />
             Star on GitHub
-          </a>
-          <a
-            href='https://patreon.com/vernu'
-            style='display: inline-block; margin: 0 10px; color: #FF424D; text-decoration: none;'
-          >
-            <img
-              src='https://c5.patreon.com/external/logo/downloads_logomark_color_on_white.png'
-              alt='Patreon'
-              style='width: 20px; vertical-align: middle;'
-            />
-            Support on Patreon
           </a>
         </div>
       </div>

--- a/api/src/openapi/swagger-config.ts
+++ b/api/src/openapi/swagger-config.ts
@@ -40,7 +40,7 @@ export interface SwaggerConfigOptions {
 
 const LICENSE = {
   name: 'MIT',
-  url: 'https://github.com/vernu/textbee/blob/main/LICENSE',
+  url: 'https://github.com/textbee/textbee/blob/main/LICENSE',
 } as const
 
 // The server and the openapi exporter both call this, so the documented paths

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
   # NestJS API
   textbee-api:
     container_name: textbee-api
-    # image: ghcr.io/vernu/textbee/api:latest
+    # image: ghcr.io/textbee/textbee/api:latest
     build:
       context: ./api
       dockerfile: Dockerfile
@@ -64,7 +64,7 @@ services:
   # Next.js Web
   textbee-web:
     container_name: textbee-web
-    # image: ghcr.io/vernu/textbee/web:latest
+    # image: ghcr.io/textbee/textbee/web:latest
     build:
       context: ./web
       dockerfile: Dockerfile

--- a/web/app/download/page.tsx
+++ b/web/app/download/page.tsx
@@ -50,7 +50,7 @@ export default function DownloadPage() {
     async function fetchReleases() {
       try {
         const response = await fetch(
-          'https://api.github.com/repos/vernu/textbee/releases'
+          'https://api.github.com/repos/textbee/textbee/releases'
         )
         if (!response.ok) {
           throw new Error('Failed to fetch releases')
@@ -318,7 +318,7 @@ export default function DownloadPage() {
               className='text-muted-foreground'
             >
               <Link
-                href='https://github.com/vernu/textbee/releases'
+                href='https://github.com/textbee/textbee/releases'
                 target='_blank'
                 rel='noopener noreferrer'
               >

--- a/web/config/external-links.ts
+++ b/web/config/external-links.ts
@@ -11,7 +11,7 @@ export function polarCustomerPortalRequestUrl(
 
 export const ExternalLinks = {
   patreon: 'https://patreon.com/vernu',
-  github: 'https://github.com/vernu/textbee',
+  github: 'https://github.com/textbee/textbee',
   discord: 'https://textbee.dev/discord',
   polar: 'https://donate.textbee.dev',
   twitter: 'https://x.com/textbeedotdev',


### PR DESCRIPTION
The repo now lives at `github.com/textbee/textbee`. This updates every hardcoded reference to the old path.

- README badges, fork link, and new-issue link
- Dashboard external links and the download page (releases API call and releases link)
- Android settings "GitHub" link
- OpenAPI license URL (`swagger-config.ts` plus the regenerated `api/openapi.json`)
- GitHub link in the three transactional email footers
- Commented ghcr image names in `docker-compose.yaml`

The Docker publish workflow builds its image names from `${{ github.repository }}`, so it follows the move with no edit.

Also in here, unrelated to the move: every entry in `.github/FUNDING.yml` is commented out, and the Patreon link is removed from the three email footers. Patreon links elsewhere in the product are unchanged.

`api/openapi.json` was regenerated with `pnpm run export:openapi` rather than hand-edited, and the output matches. The matching spec update for the marketing site is in a separate PR that should merge after this one, since its CI diffs against this repo's `main`.

Existing Android installs keep hitting the GitHub redirect until they update to a build containing this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)