### PR TITLE
Fix the Android build and compile fork pull requests

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -101,3 +101,48 @@ jobs:
           name: textbee-${{ matrix.variant }}-build-${{ env.SAFE_REF_NAME }}-${{ github.sha }}.apk
           path: android/app/build/outputs/apk/${{ matrix.variant }}/debug/app-${{ matrix.variant }}-debug.apk
           retention-days: 7
+
+  build-fork:
+    name: Compile Android (fork PR)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # The build job above needs secrets that GitHub withholds from fork pull
+    # requests. Compile the dev variant against the committed sample Firebase
+    # config instead, so outside contributions are still checked. No artifact
+    # is uploaded, since the resulting APK points at a placeholder project.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: '7.2'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x android/gradlew
+
+      - name: Create debug keystore
+        run: |
+          mkdir -p ~/.android
+          keytool -genkey -v -keystore ~/.android/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+
+      - name: Use sample google-services.json
+        run: cp android/app/src/dev/google-services.sample.json android/app/src/dev/google-services.json
+
+      - name: Build
+        run: |
+          cd android
+          ./gradlew assembleDevDebug

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -88,6 +88,7 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.8.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'


### PR DESCRIPTION
The Android workflow has been red on `main` since #308 merged. The build fails on both matrix variants with:

```
SMSFilterActivity.java:242: error: cannot find symbol
                int pos = holder.getBindingAdapterPosition();
  symbol:   method getBindingAdapterPosition()
```

`RecyclerView.ViewHolder.getBindingAdapterPosition()` landed in RecyclerView 1.2.0. `android/app/build.gradle` declared no RecyclerView dependency, so the version resolved transitively from `material:1.8.0`, which pulls 1.1.0.

Declaring `androidx.recyclerview:recyclerview:1.3.2` explicitly fixes the build and keeps the available API independent of whatever `material` happens to pull in. `:app:dependencies` now shows `recyclerview:1.0.0 -> 1.3.2`. No source change: resolving the position at click time is the correct fix for #281, it just needed a RecyclerView that has the method.

The second commit covers why this was not caught before merge. The build job is skipped on fork pull requests, because `google-services.json` is written from repository secrets and GitHub withholds those from forks. #308 came from a fork, so `Build Android` reported `skipping` on the PR and the break reached `main` uncompiled. The new `build-fork` job runs only on fork PRs and compiles the dev variant against the sample Firebase config already committed at `android/app/src/dev/google-services.sample.json`. It uploads no artifact, since the resulting APK points at a placeholder project. The two jobs' conditions are mutually exclusive, so exactly one runs per pull request.

Verified locally with `assembleDevDebug` and `assembleProdDebug`, and with the sample config swapped in for the fork path. CI on this branch via `workflow_dispatch`: both variants pass, and `build-fork` correctly skips on a non-PR event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)