### PR TITLE
Lowercase textbee branding in copy and identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ See [textbee.dev](https://textbee.dev) for current plans and limits. You can alw
    && cd ../api && cp .env.example .env
    ```
 2. Navigate to root folder and execute docker-compose.yml file.    
-   This will spin up `web` container, `api` container alongside with `MongoDB` and `MongoExpress`. `TextBee` database will be automatically created.
+   This will spin up `web` container, `api` container alongside with `MongoDB` and `MongoExpress`. `textbee` database will be automatically created.
    ```bash
    docker compose up -d
    ```

--- a/android/.idea/.name
+++ b/android/.idea/.name
@@ -1,1 +1,1 @@
-TextBee
+textbee

--- a/android/MIGRATION.md
+++ b/android/MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TextBee Android is mid-migration from a Java/XML legacy codebase to Kotlin + Jetpack Compose. The new UI runs in parallel with the legacy UI — users can switch between them via Settings. The SplashActivity routes to the appropriate UI on launch.
+textbee Android is mid-migration from a Java/XML legacy codebase to Kotlin + Jetpack Compose. The new UI runs in parallel with the legacy UI — users can switch between them via Settings. The SplashActivity routes to the appropriate UI on launch.
 
 ---
 
@@ -12,7 +12,7 @@ TextBee Android is mid-migration from a Java/XML legacy codebase to Kotlin + Jet
 | File | Notes |
 |---|---|
 | `ui/theme/Color.kt` | Brand orange (`#C4620A`), full light/dark palette |
-| `ui/theme/Theme.kt` | `TextBeeTheme` wrapper, `dynamicColor = false` to preserve brand color |
+| `ui/theme/Theme.kt` | `TextbeeTheme` wrapper, `dynamicColor = false` to preserve brand color |
 | `ui/theme/Type.kt` | Material3 typography scale |
 
 ### Infrastructure
@@ -104,7 +104,7 @@ All helpers are Kotlin `object` with `@JvmStatic` on every public method — at 
 |---|---|---|
 | `AppConstants.java` | Low | Constants only — convert when touching other things |
 | `SMSGatewayApplication.java` | Low | Application class, minimal logic |
-| `TextBeeUtils.java` | Medium | Heavily used utility; convert once helpers are stable |
+| `TextbeeUtils.java` | Medium | Heavily used utility; convert once helpers are stable |
 | `ApiManager.java` | Low | Still used by legacy UI; delete after legacy removal |
 
 ### Activities (Legacy UI)
@@ -181,7 +181,7 @@ Once Compose UI is stable and rolled out to all users, remove the legacy UI enti
 
 - **`dynamicColor = false`** in `Theme.kt` — Material You overrides the brand orange on Android 12+; must stay false
 - **`primaryContainer` avoided** in TopAppBar/nav — causes orange-on-orange in dark mode; use `surface` for bars, `surfaceVariant` for nav indicator
-- **Java/Kotlin interop** — Only `ApiManager.java`, `TextBeeUtils.java`, legacy activities, and `GatewayApiService.java` remain Java; all others are Kotlin
+- **Java/Kotlin interop** — Only `ApiManager.java`, `TextbeeUtils.java`, legacy activities, and `GatewayApiService.java` remain Java; all others are Kotlin
 - **WorkManager workers** — kept as `Worker` subclass (not `CoroutineWorker`) to avoid adding `work-runtime-ktx`; straightforward conversion candidate in a future cleanup
 - **Sticky notification on Android 12+** — `ForegroundServiceStartNotAllowedException` is caught broadly; `DashboardViewModel` restarts service on every launch to compensate for OS killing it in the background
 - **Room DB** — all DB logic remains commented out; do not uncomment until the feature is explicitly re-enabled

--- a/android/app/src/main/java/com/vernu/sms/TextbeeUtils.java
+++ b/android/app/src/main/java/com/vernu/sms/TextbeeUtils.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class TextBeeUtils {
-    private static final String TAG = "TextBeeUtils";
+public class TextbeeUtils {
+    private static final String TAG = "TextbeeUtils";
     
     public static boolean isPermissionGranted(Context context, String permission) {
         return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED;

--- a/android/app/src/main/java/com/vernu/sms/activities/MainActivity.java
+++ b/android/app/src/main/java/com/vernu/sms/activities/MainActivity.java
@@ -31,7 +31,7 @@ import com.google.zxing.integration.android.IntentResult;
 import com.vernu.sms.ApiManager;
 import com.vernu.sms.AppConstants;
 import com.vernu.sms.BuildConfig;
-import com.vernu.sms.TextBeeUtils;
+import com.vernu.sms.TextbeeUtils;
 import com.vernu.sms.R;
 import com.vernu.sms.dtos.RegisterDeviceInputDTO;
 import com.vernu.sms.dtos.RegisterDeviceResponseDTO;
@@ -120,7 +120,7 @@ public class MainActivity extends AppCompatActivity {
         boolean gatewayEnabled = SharedPreferenceHelper.getSharedPreferenceBoolean(mContext, AppConstants.SHARED_PREFS_GATEWAY_ENABLED_KEY, false);
         boolean stickyNotificationEnabled = SharedPreferenceHelper.getSharedPreferenceBoolean(mContext, AppConstants.SHARED_PREFS_STICKY_NOTIFICATION_ENABLED_KEY, false);
         if (gatewayEnabled && stickyNotificationEnabled) {
-            TextBeeUtils.startStickyNotificationService(mContext);
+            TextbeeUtils.startStickyNotificationService(mContext);
             Log.d(TAG, "Starting sticky notification service on app start");
         }
 
@@ -136,7 +136,7 @@ public class MainActivity extends AppCompatActivity {
             registerDeviceBtn.setText("Update");
         }
 
-        String[] missingPermissions = Arrays.stream(AppConstants.requiredPermissions).filter(permission -> !TextBeeUtils.isPermissionGranted(mContext, permission)).toArray(String[]::new);
+        String[] missingPermissions = Arrays.stream(AppConstants.requiredPermissions).filter(permission -> !TextbeeUtils.isPermissionGranted(mContext, permission)).toArray(String[]::new);
         if (missingPermissions.length == 0) {
             grantSMSPermissionBtn.setEnabled(false);
             grantSMSPermissionBtn.setText("Permission Granted");
@@ -147,7 +147,7 @@ public class MainActivity extends AppCompatActivity {
             grantSMSPermissionBtn.setOnClickListener(this::handleRequestPermissions);
         }
 
-//        TextBeeUtils.startStickyNotificationService(mContext);
+//        TextbeeUtils.startStickyNotificationService(mContext);
 
         copyDeviceIdImgBtn.setOnClickListener(view -> {
             ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
@@ -191,12 +191,12 @@ public class MainActivity extends AppCompatActivity {
                     if (enabled) {
                         // Check if sticky notification is enabled
                         if (SharedPreferenceHelper.getSharedPreferenceBoolean(mContext, AppConstants.SHARED_PREFS_STICKY_NOTIFICATION_ENABLED_KEY, false)) {
-                            TextBeeUtils.startStickyNotificationService(mContext);
+                            TextbeeUtils.startStickyNotificationService(mContext);
                         }
                         // Schedule heartbeat
                         HeartbeatManager.scheduleHeartbeat(mContext);
                     } else {
-                        TextBeeUtils.stopStickyNotificationService(mContext);
+                        TextbeeUtils.stopStickyNotificationService(mContext);
                         // Cancel heartbeat
                         HeartbeatManager.cancelHeartbeat(mContext);
                     }
@@ -207,7 +207,7 @@ public class MainActivity extends AppCompatActivity {
                     Snackbar.make(view, "An error occurred :(", Snackbar.LENGTH_LONG).show();
                     Log.e(TAG, "API_ERROR "+ t.getMessage());
                     Log.e(TAG, "API_ERROR "+ t.getLocalizedMessage());
-                    TextBeeUtils.logException(t, "Error updating device");
+                    TextbeeUtils.logException(t, "Error updating device");
                     compoundButton.setEnabled(true);
                 }
             });
@@ -228,10 +228,10 @@ public class MainActivity extends AppCompatActivity {
             SharedPreferenceHelper.setSharedPreferenceBoolean(mContext, AppConstants.SHARED_PREFS_STICKY_NOTIFICATION_ENABLED_KEY, isChecked);
             
             if (isChecked) {
-                TextBeeUtils.startStickyNotificationService(mContext);
+                TextbeeUtils.startStickyNotificationService(mContext);
                 Snackbar.make(view, "Background service enabled - app will be more reliable", Snackbar.LENGTH_LONG).show();
             } else {
-                TextBeeUtils.stopStickyNotificationService(mContext);
+                TextbeeUtils.stopStickyNotificationService(mContext);
                 Snackbar.make(view, "Background service disabled - app may be killed when in background", Snackbar.LENGTH_LONG).show();
             }
         });
@@ -346,7 +346,7 @@ public class MainActivity extends AppCompatActivity {
             defaultSimSlotRadioGroup.addView(defaultSimSlotRadioBtn);
             
             // Create radio buttons for each SIM with proper styling
-            TextBeeUtils.getAvailableSimSlots(mContext).forEach(subscriptionInfo -> {
+            TextbeeUtils.getAvailableSimSlots(mContext).forEach(subscriptionInfo -> {
                 String displayName = subscriptionInfo.getDisplayName() != null ? subscriptionInfo.getDisplayName().toString() : "Unknown";
                 String simInfo = displayName + " (Subscription ID: " + subscriptionInfo.getSubscriptionId() + ")";
                 RadioButton radioButton = new RadioButton(mContext);
@@ -464,7 +464,7 @@ public class MainActivity extends AppCompatActivity {
         if (requestCode != PERMISSION_REQUEST_CODE) {
             return;
         }
-        boolean allPermissionsGranted = Arrays.stream(permissions).allMatch(permission -> TextBeeUtils.isPermissionGranted(mContext, permission));
+        boolean allPermissionsGranted = Arrays.stream(permissions).allMatch(permission -> TextbeeUtils.isPermissionGranted(mContext, permission));
         if (allPermissionsGranted) {
             Snackbar.make(findViewById(R.id.grantSMSPermissionBtn), "All Permissions Granted", Snackbar.LENGTH_SHORT).show();
             grantSMSPermissionBtn.setEnabled(false);
@@ -518,7 +518,7 @@ public class MainActivity extends AppCompatActivity {
                     // Collect SIM information
                     SimInfoCollectionDTO simInfoCollection = new SimInfoCollectionDTO();
                     simInfoCollection.setLastUpdated(System.currentTimeMillis());
-                    simInfoCollection.setSims(TextBeeUtils.collectSimInfo(mContext));
+                    simInfoCollection.setSims(TextbeeUtils.collectSimInfo(mContext));
                     registerDeviceInput.setSimInfo(simInfoCollection);
                     
                     // If the user provided a device ID, use it for updating instead of creating new
@@ -583,7 +583,7 @@ public class MainActivity extends AppCompatActivity {
                                 Snackbar.make(view, "An error occurred :(", Snackbar.LENGTH_LONG).show();
                                 Log.e(TAG, "API_ERROR "+ t.getMessage());
                                 Log.e(TAG, "API_ERROR "+ t.getLocalizedMessage());
-                                TextBeeUtils.logException(t, "Error registering device");
+                                TextbeeUtils.logException(t, "Error registering device");
                                 registerDeviceBtn.setEnabled(true);
                                 registerDeviceBtn.setText("Update");
                             }
@@ -648,7 +648,7 @@ public class MainActivity extends AppCompatActivity {
                             Snackbar.make(view, "An error occurred :(", Snackbar.LENGTH_LONG).show();
                             Log.e(TAG, "API_ERROR "+ t.getMessage());
                             Log.e(TAG, "API_ERROR "+ t.getLocalizedMessage());
-                            TextBeeUtils.logException(t, "Error registering device");
+                            TextbeeUtils.logException(t, "Error registering device");
                             registerDeviceBtn.setEnabled(true);
                             registerDeviceBtn.setText("Update");
                         }
@@ -700,7 +700,7 @@ public class MainActivity extends AppCompatActivity {
                     // Collect SIM information
                     SimInfoCollectionDTO simInfoCollection = new SimInfoCollectionDTO();
                     simInfoCollection.setLastUpdated(System.currentTimeMillis());
-                    simInfoCollection.setSims(TextBeeUtils.collectSimInfo(mContext));
+                    simInfoCollection.setSims(TextbeeUtils.collectSimInfo(mContext));
                     updateDeviceInput.setSimInfo(simInfoCollection);
 
                     Call<RegisterDeviceResponseDTO> apiCall = ApiManager.getApiService().updateDevice(deviceIdToUse, apiKey, updateDeviceInput);
@@ -760,7 +760,7 @@ public class MainActivity extends AppCompatActivity {
                             Snackbar.make(view, "An error occurred :(", Snackbar.LENGTH_LONG).show();
                             Log.e(TAG, "API_ERROR "+ t.getMessage());
                             Log.e(TAG, "API_ERROR "+ t.getLocalizedMessage());
-                            TextBeeUtils.logException(t, "Error updating device");
+                            TextbeeUtils.logException(t, "Error updating device");
                             registerDeviceBtn.setEnabled(true);
                             registerDeviceBtn.setText("Update");
                         }
@@ -769,12 +769,12 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void handleRequestPermissions(View view) {
-        boolean allPermissionsGranted = Arrays.stream(AppConstants.requiredPermissions).allMatch(permission -> TextBeeUtils.isPermissionGranted(mContext, permission));
+        boolean allPermissionsGranted = Arrays.stream(AppConstants.requiredPermissions).allMatch(permission -> TextbeeUtils.isPermissionGranted(mContext, permission));
         if (allPermissionsGranted) {
             Snackbar.make(view, "Already got permissions", Snackbar.LENGTH_SHORT).show();
             return;
         }
-        String[] permissionsToRequest = Arrays.stream(AppConstants.requiredPermissions).filter(permission -> !TextBeeUtils.isPermissionGranted(mContext, permission)).toArray(String[]::new);
+        String[] permissionsToRequest = Arrays.stream(AppConstants.requiredPermissions).filter(permission -> !TextbeeUtils.isPermissionGranted(mContext, permission)).toArray(String[]::new);
         Snackbar.make(view, "Please Grant Required Permissions to continue", Snackbar.LENGTH_SHORT).show();
         ActivityCompat.requestPermissions(this, permissionsToRequest, PERMISSION_REQUEST_CODE);
     }

--- a/android/app/src/main/java/com/vernu/sms/helpers/HeartbeatHelper.kt
+++ b/android/app/src/main/java/com/vernu/sms/helpers/HeartbeatHelper.kt
@@ -13,7 +13,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.vernu.sms.ApiManager
 import com.vernu.sms.AppConstants
 import com.vernu.sms.BuildConfig
-import com.vernu.sms.TextBeeUtils
+import com.vernu.sms.TextbeeUtils
 import com.vernu.sms.dtos.HeartbeatInputDTO
 import com.vernu.sms.dtos.SimInfoCollectionDTO
 import java.io.IOException
@@ -115,7 +115,7 @@ object HeartbeatHelper {
             // SIM info
             heartbeatInput.simInfo = SimInfoCollectionDTO().apply {
                 lastUpdated = System.currentTimeMillis()
-                sims = TextBeeUtils.collectSimInfo(context)
+                sims = TextbeeUtils.collectSimInfo(context)
             }
 
             // Send heartbeat (blocking)

--- a/android/app/src/main/java/com/vernu/sms/helpers/SMSHelper.kt
+++ b/android/app/src/main/java/com/vernu/sms/helpers/SMSHelper.kt
@@ -8,7 +8,7 @@ import android.os.Build
 import android.telephony.SmsManager
 import android.util.Log
 import com.vernu.sms.AppConstants
-import com.vernu.sms.TextBeeUtils
+import com.vernu.sms.TextbeeUtils
 import com.vernu.sms.dtos.SMSDTO
 import com.vernu.sms.receivers.SMSStatusReceiver
 import com.vernu.sms.workers.SMSStatusUpdateWorker
@@ -24,7 +24,7 @@ object SMSHelper {
         smsBatchId: String,
         context: Context
     ): Boolean {
-        if (!TextBeeUtils.isPermissionGranted(context, Manifest.permission.SEND_SMS)) {
+        if (!TextbeeUtils.isPermissionGranted(context, Manifest.permission.SEND_SMS)) {
             Log.e(TAG, "SMS permission not granted. Unable to send SMS.")
             reportPermissionError(context, smsId, smsBatchId)
             return false
@@ -62,8 +62,8 @@ object SMSHelper {
         smsBatchId: String,
         context: Context
     ): Boolean {
-        if (!TextBeeUtils.isPermissionGranted(context, Manifest.permission.SEND_SMS) ||
-            !TextBeeUtils.isPermissionGranted(context, Manifest.permission.READ_PHONE_STATE)
+        if (!TextbeeUtils.isPermissionGranted(context, Manifest.permission.SEND_SMS) ||
+            !TextbeeUtils.isPermissionGranted(context, Manifest.permission.READ_PHONE_STATE)
         ) {
             Log.e(TAG, "SMS or Phone State permission not granted. Unable to send SMS from specific SIM.")
             reportPermissionError(context, smsId, smsBatchId)

--- a/android/app/src/main/java/com/vernu/sms/receivers/BootCompletedReceiver.kt
+++ b/android/app/src/main/java/com/vernu/sms/receivers/BootCompletedReceiver.kt
@@ -9,7 +9,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.vernu.sms.ApiManager
 import com.vernu.sms.AppConstants
 import com.vernu.sms.BuildConfig
-import com.vernu.sms.TextBeeUtils
+import com.vernu.sms.TextbeeUtils
 import com.vernu.sms.dtos.RegisterDeviceInputDTO
 import com.vernu.sms.dtos.RegisterDeviceResponseDTO
 import com.vernu.sms.helpers.HeartbeatManager
@@ -29,9 +29,9 @@ class BootCompletedReceiver : BroadcastReceiver() {
         val stickyNotificationEnabled = SharedPreferenceHelper.getSharedPreferenceBoolean(
             context, AppConstants.SHARED_PREFS_STICKY_NOTIFICATION_ENABLED_KEY, false
         )
-        if (stickyNotificationEnabled && TextBeeUtils.isPermissionGranted(context, Manifest.permission.RECEIVE_SMS)) {
+        if (stickyNotificationEnabled && TextbeeUtils.isPermissionGranted(context, Manifest.permission.RECEIVE_SMS)) {
             Log.i(TAG, "Device booted, starting sticky notification service")
-            TextBeeUtils.startStickyNotificationService(context)
+            TextbeeUtils.startStickyNotificationService(context)
         }
 
         val deviceId = SharedPreferenceHelper.getSharedPreferenceString(

--- a/android/app/src/main/java/com/vernu/sms/services/StickyNotificationService.kt
+++ b/android/app/src/main/java/com/vernu/sms/services/StickyNotificationService.kt
@@ -81,7 +81,7 @@ class StickyNotificationService : Service() {
             )
 
             Notification.Builder(this, NOTIFICATION_CHANNEL_ID)
-                .setContentTitle("TextBee Active")
+                .setContentTitle("textbee Active")
                 .setContentText("SMS gateway service is active")
                 .setContentIntent(pendingIntent)
                 .setOngoing(true)
@@ -90,7 +90,7 @@ class StickyNotificationService : Service() {
         } else {
             @Suppress("DEPRECATION")
             NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
-                .setContentTitle("TextBee Active")
+                .setContentTitle("textbee Active")
                 .setContentText("SMS gateway service is active")
                 .setOngoing(true)
                 .setSmallIcon(R.mipmap.ic_launcher)

--- a/android/app/src/main/java/com/vernu/sms/ui/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/dashboard/DashboardViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.vernu.sms.ApiManagerKt
 import com.vernu.sms.AppConstants
-import com.vernu.sms.TextBeeUtils
+import com.vernu.sms.TextbeeUtils
 import com.vernu.sms.dtos.RegisterDeviceInputDTO
 import com.vernu.sms.dtos.SimInfoDTO
 import com.vernu.sms.dtos.SubscriptionResponse
@@ -69,7 +69,7 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
         val lastHeartbeatMs = lastHeartbeatStr?.toLongOrNull()
 
         val sims = try {
-            TextBeeUtils.collectSimInfo(context)
+            TextbeeUtils.collectSimInfo(context)
         } catch (e: Exception) {
             emptyList<SimInfoDTO>()
         }
@@ -91,7 +91,7 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
         // Restart sticky notification service on every launch if it should be running,
         // matching legacy MainActivity behaviour (service is killed by OS on modern Android).
         if (isEnabled) {
-            TextBeeUtils.startStickyNotificationService(context)
+            TextbeeUtils.startStickyNotificationService(context)
             if (deviceId.isNotEmpty()) HeartbeatManager.scheduleHeartbeat(context)
         }
     }
@@ -108,7 +108,7 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
                     _state.update { it.copy(userProfile = response.body()?.data) }
                 }
             } catch (e: Exception) {
-                TextBeeUtils.logException(e, "User profile fetch failed")
+                TextbeeUtils.logException(e, "User profile fetch failed")
             }
         }
     }
@@ -132,7 +132,7 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
                 }
             } catch (e: Exception) {
                 _state.update { it.copy(isSubscriptionLoading = false, subscriptionUnavailable = true) }
-                TextBeeUtils.logException(e, "Subscription fetch failed")
+                TextbeeUtils.logException(e, "Subscription fetch failed")
             }
         }
     }
@@ -171,15 +171,15 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
                                     context, AppConstants.SHARED_PREFS_STICKY_NOTIFICATION_ENABLED_KEY, false
                                 )
                             ) {
-                                TextBeeUtils.startStickyNotificationService(context)
+                                TextbeeUtils.startStickyNotificationService(context)
                             }
                             HeartbeatManager.scheduleHeartbeat(context)
                         } else {
-                            TextBeeUtils.stopStickyNotificationService(context)
+                            TextbeeUtils.stopStickyNotificationService(context)
                             HeartbeatManager.cancelHeartbeat(context)
                         }
                     } catch (e: Exception) {
-                        TextBeeUtils.logException(e, "Gateway service toggle failed")
+                        TextbeeUtils.logException(e, "Gateway service toggle failed")
                     }
                     _state.update {
                         it.copy(
@@ -198,7 +198,7 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
                     _state.update { it.copy(userMessage = message) }
                 }
             } catch (e: Exception) {
-                TextBeeUtils.logException(e, "Gateway toggle failed")
+                TextbeeUtils.logException(e, "Gateway toggle failed")
                 _state.update { it.copy(userMessage = "Couldn't update the gateway. Please check your connection.") }
             } finally {
                 _state.update { it.copy(isTogglingGateway = false) }

--- a/android/app/src/main/java/com/vernu/sms/ui/main/NewMainActivity.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/main/NewMainActivity.kt
@@ -31,7 +31,7 @@ import com.vernu.sms.ui.messages.MessagesScreen
 import com.vernu.sms.ui.onboarding.OnboardingActivity
 import com.vernu.sms.ui.settings.SMSFilterScreen
 import com.vernu.sms.ui.settings.SettingsScreen
-import com.vernu.sms.ui.theme.TextBeeTheme
+import com.vernu.sms.ui.theme.TextbeeTheme
 
 enum class MainDestination(val label: String, val icon: ImageVector) {
     DASHBOARD("Dashboard", Icons.Default.Dashboard),
@@ -44,7 +44,7 @@ class NewMainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            TextBeeTheme {
+            TextbeeTheme {
                 val navController = rememberNavController()
                 MainScaffold(
                     navController = navController,

--- a/android/app/src/main/java/com/vernu/sms/ui/onboarding/OnboardingActivity.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/onboarding/OnboardingActivity.kt
@@ -14,7 +14,7 @@ import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import com.vernu.sms.ui.main.NewMainActivity
 import com.vernu.sms.ui.onboarding.screens.*
-import com.vernu.sms.ui.theme.TextBeeTheme
+import com.vernu.sms.ui.theme.TextbeeTheme
 
 class OnboardingActivity : ComponentActivity() {
 
@@ -30,7 +30,7 @@ class OnboardingActivity : ComponentActivity() {
         }
 
         setContent {
-            TextBeeTheme {
+            TextbeeTheme {
                 val navController = rememberNavController()
                 OnboardingNavGraph(
                     navController = navController,

--- a/android/app/src/main/java/com/vernu/sms/ui/onboarding/OnboardingViewModel.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/onboarding/OnboardingViewModel.kt
@@ -8,7 +8,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.vernu.sms.ApiManagerKt
 import com.vernu.sms.AppConstants
 import com.vernu.sms.BuildConfig
-import com.vernu.sms.TextBeeUtils
+import com.vernu.sms.TextbeeUtils
 import com.vernu.sms.dtos.RegisterDeviceInputDTO
 import com.vernu.sms.dtos.SimInfoCollectionDTO
 import com.vernu.sms.helpers.HeartbeatManager
@@ -95,7 +95,7 @@ class OnboardingViewModel : ViewModel() {
                 val fcmToken = getFcmToken()
                 val collectedSimInfo = SimInfoCollectionDTO().apply {
                     lastUpdated = System.currentTimeMillis()
-                    sims = TextBeeUtils.collectSimInfo(context)
+                    sims = TextbeeUtils.collectSimInfo(context)
                 }
                 val input = RegisterDeviceInputDTO().apply {
                     this.fcmToken = fcmToken
@@ -179,7 +179,7 @@ class OnboardingViewModel : ViewModel() {
                     else -> "Something went wrong. Please try again."
                 }
                 _state.update { it.copy(isLoading = false, errorMessage = message) }
-                TextBeeUtils.logException(e, "Onboarding device registration failed")
+                TextbeeUtils.logException(e, "Onboarding device registration failed")
             }
         }
     }

--- a/android/app/src/main/java/com/vernu/sms/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/settings/SettingsScreen.kt
@@ -268,7 +268,7 @@ fun SettingsScreen(
                                 type = "text/plain"
                                 putExtra(Intent.EXTRA_TEXT, shareText)
                             },
-                            "Share TextBee"
+                            "Share textbee"
                         )
                     )
                 }

--- a/android/app/src/main/java/com/vernu/sms/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/settings/SettingsViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.vernu.sms.ApiManagerKt
 import com.vernu.sms.AppConstants
 import com.vernu.sms.BuildConfig
-import com.vernu.sms.TextBeeUtils
+import com.vernu.sms.TextbeeUtils
 import com.vernu.sms.dtos.RegisterDeviceInputDTO
 import com.vernu.sms.helpers.SharedPreferenceHelper
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,7 +76,7 @@ class SettingsViewModel(app: Application) : AndroidViewModel(app) {
         )
 
         val sims = try {
-            TextBeeUtils.getAvailableSimSlots(context).map { info ->
+            TextbeeUtils.getAvailableSimSlots(context).map { info ->
                 SimOption(
                     subscriptionId = info.subscriptionId,
                     displayName = "${info.carrierName} (SIM ${info.simSlotIndex + 1})"
@@ -116,10 +116,10 @@ class SettingsViewModel(app: Application) : AndroidViewModel(app) {
                     )
                     _state.update { it.copy(isGatewayEnabled = enabled) }
                     if (enabled) {
-                        TextBeeUtils.startStickyNotificationService(context)
+                        TextbeeUtils.startStickyNotificationService(context)
                         com.vernu.sms.helpers.HeartbeatManager.scheduleHeartbeat(context)
                     } else {
-                        TextBeeUtils.stopStickyNotificationService(context)
+                        TextbeeUtils.stopStickyNotificationService(context)
                         com.vernu.sms.helpers.HeartbeatManager.cancelHeartbeat(context)
                     }
                 } else {
@@ -127,7 +127,7 @@ class SettingsViewModel(app: Application) : AndroidViewModel(app) {
                 }
             } catch (e: Exception) {
                 _state.update { it.copy(snackbarMessage = "Network error. Try again.") }
-                TextBeeUtils.logException(e, "Gateway toggle from settings failed")
+                TextbeeUtils.logException(e, "Gateway toggle from settings failed")
             }
         }
     }
@@ -144,10 +144,10 @@ class SettingsViewModel(app: Application) : AndroidViewModel(app) {
             context, AppConstants.SHARED_PREFS_STICKY_NOTIFICATION_ENABLED_KEY, enabled
         )
         try {
-            if (enabled) TextBeeUtils.startStickyNotificationService(context)
-            else TextBeeUtils.stopStickyNotificationService(context)
+            if (enabled) TextbeeUtils.startStickyNotificationService(context)
+            else TextbeeUtils.stopStickyNotificationService(context)
         } catch (e: Exception) {
-            TextBeeUtils.logException(e, "Sticky notification toggle failed")
+            TextbeeUtils.logException(e, "Sticky notification toggle failed")
             _state.update { it.copy(snackbarMessage = "Could not start notification service") }
         }
         _state.update { it.copy(isStickyNotificationEnabled = enabled) }
@@ -188,7 +188,7 @@ class SettingsViewModel(app: Application) : AndroidViewModel(app) {
                 }
             } catch (e: Exception) {
                 _state.update { it.copy(snackbarMessage = "Network error. Try again.") }
-                TextBeeUtils.logException(e, "Save device name failed")
+                TextbeeUtils.logException(e, "Save device name failed")
             } finally {
                 _state.update { it.copy(isSavingDeviceName = false) }
             }

--- a/android/app/src/main/java/com/vernu/sms/ui/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/splash/SplashActivity.kt
@@ -23,14 +23,14 @@ import com.vernu.sms.activities.MainActivity
 import com.vernu.sms.helpers.SharedPreferenceHelper
 import com.vernu.sms.ui.main.NewMainActivity
 import com.vernu.sms.ui.onboarding.OnboardingActivity
-import com.vernu.sms.ui.theme.TextBeeTheme
+import com.vernu.sms.ui.theme.TextbeeTheme
 
 class SplashActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            TextBeeTheme {
+            TextbeeTheme {
                 SplashContent()
             }
         }

--- a/android/app/src/main/java/com/vernu/sms/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/vernu/sms/ui/theme/Theme.kt
@@ -53,7 +53,7 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 @Composable
-fun TextBeeTheme(
+fun TextbeeTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit

--- a/android/app/src/main/java/com/vernu/sms/workers/SmsSendWorker.kt
+++ b/android/app/src/main/java/com/vernu/sms/workers/SmsSendWorker.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.work.*
 import com.vernu.sms.AppConstants
-import com.vernu.sms.TextBeeUtils
+import com.vernu.sms.TextbeeUtils
 import com.vernu.sms.helpers.SMSHelper
 import com.vernu.sms.helpers.SharedPreferenceHelper
 
@@ -81,7 +81,7 @@ class SmsSendWorker(context: Context, workerParams: WorkerParameters) : Worker(c
     }
 
     private fun resolveSim(context: Context, backendSimId: Int): Int? {
-        if (backendSimId != -1 && TextBeeUtils.isValidSubscriptionId(context, backendSimId)) {
+        if (backendSimId != -1 && TextbeeUtils.isValidSubscriptionId(context, backendSimId)) {
             Log.d(TAG, "Using backend-provided SIM subscription ID: $backendSimId")
             return backendSimId
         }
@@ -89,7 +89,7 @@ class SmsSendWorker(context: Context, workerParams: WorkerParameters) : Worker(c
         val preferredSim = SharedPreferenceHelper.getSharedPreferenceInt(
             context, AppConstants.SHARED_PREFS_PREFERRED_SIM_KEY, -1
         )
-        if (preferredSim != -1 && TextBeeUtils.isValidSubscriptionId(context, preferredSim)) {
+        if (preferredSim != -1 && TextbeeUtils.isValidSubscriptionId(context, preferredSim)) {
             Log.d(TAG, "Using app-preferred SIM subscription ID: $preferredSim")
             return preferredSim
         }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -12,5 +12,5 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "TextBee"
+rootProject.name = "textbee"
 include ':app'

--- a/api/src/mail/templates/account-deletion-request.hbs
+++ b/api/src/mail/templates/account-deletion-request.hbs
@@ -16,7 +16,7 @@
 
     <p>Hello {{name}},</p>
 
-    <p>We have received your request to delete your TextBee account. We're sorry to see you go.</p>
+    <p>We have received your request to delete your textbee account. We're sorry to see you go.</p>
 
     <div class='notice'>
       <p><strong>Important:</strong> Your account has been marked for deletion and will be processed within 7 days. During this period:</p>

--- a/api/src/mail/templates/password-reset-request.hbs
+++ b/api/src/mail/templates/password-reset-request.hbs
@@ -79,7 +79,7 @@
       <div class='footer'>
         <p>
           Thank you,<br />
-          <strong>TextBee.dev</strong>
+          <strong>textbee.dev</strong>
         </p>
         <p style='font-size: 12px; color: #999;'>
           If you didn't request this password reset, you can safely ignore this

--- a/api/src/mail/templates/password-reset-success.hbs
+++ b/api/src/mail/templates/password-reset-success.hbs
@@ -43,7 +43,7 @@
       <div class='footer'>
         <p>
           Thank you,<br />
-          <strong>TextBee.dev</strong>
+          <strong>textbee.dev</strong>
         </p>
         <p style='font-size: 12px; color: #999;'>
           If you didn't reset your password, please contact our support team immediately.

--- a/api/src/mail/templates/verify-email.hbs
+++ b/api/src/mail/templates/verify-email.hbs
@@ -48,7 +48,7 @@
 
       <p>Hello {{name}},</p>
 
-      <p>Welcome to TextBee! To complete your registration and verify your email address, please click the button below.</p>
+      <p>Welcome to textbee! To complete your registration and verify your email address, please click the button below.</p>
 
       <div style='text-align: center;'>
         <a href='{{verificationLink}}' class='reset-button'>Verify Email</a>
@@ -66,10 +66,10 @@
       <div class='footer'>
         <p>
           Thank you,<br />
-          <strong>TextBee.dev</strong>
+          <strong>textbee.dev</strong>
         </p>
         <p style='font-size: 12px; color: #999;'>
-          If you didn't create an account with TextBee, you can safely ignore this email.
+          If you didn't create an account with textbee, you can safely ignore this email.
         </p>
 
         <div class='divider'></div>

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -34,8 +34,8 @@ async function bootstrap() {
   applyApiConventions(app)
 
   const config = buildSwaggerConfig({
-    title: 'TextBee API Docs',
-    description: 'TextBee - Android SMS Gateway API Docs',
+    title: 'textbee API Docs',
+    description: 'textbee - Android SMS Gateway API Docs',
   })
   const document = SwaggerModule.createDocument(app, config)
   // Every route that carries the spec itself, including swagger-ui-init.js,

--- a/web/app/(app)/contribute/page.tsx
+++ b/web/app/(app)/contribute/page.tsx
@@ -48,7 +48,7 @@ export default function ContributePage() {
   return (
     <div className='min-h-screen p-4 md:p-8 space-y-8'>
       <div className='text-center space-y-4'>
-        <h1 className='text-4xl font-bold'>Support TextBee</h1>
+        <h1 className='text-4xl font-bold'>Support textbee</h1>
         <p className='text-muted-foreground max-w-2xl mx-auto'>
           Your contribution, whether financial or through code, helps keep this
           project alive and growing.
@@ -63,7 +63,7 @@ export default function ContributePage() {
               Financial Support
             </CardTitle>
             <CardDescription>
-              Help sustain TextBee&apos;s development through financial
+              Help sustain textbee&apos;s development through financial
               contributions
             </CardDescription>
           </CardHeader>
@@ -174,7 +174,7 @@ export default function ContributePage() {
               Code Contributions
             </CardTitle>
             <CardDescription>
-              Help improve TextBee by contributing to the codebase
+              Help improve textbee by contributing to the codebase
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/web/app/(app)/dashboard/(components)/api-keys/generate-api-key.tsx
+++ b/web/app/(app)/dashboard/(components)/api-keys/generate-api-key.tsx
@@ -153,7 +153,7 @@ const GenerateApiKey = forwardRef<GenerateApiKeyHandle, GenerateApiKeyProps>(
                     For Device Registration
                   </h4>
                   <p className='text-muted-foreground'>
-                    Open the TextBee app and scan the QR code, or manually enter
+                    Open the textbee app and scan the QR code, or manually enter
                     the API key in the app and click register/update.
                   </p>
                 </div>
@@ -181,7 +181,7 @@ const GenerateApiKey = forwardRef<GenerateApiKeyHandle, GenerateApiKeyProps>(
                   <h4 className='font-medium'>For External Services</h4>
                   <p className='text-muted-foreground'>
                     Copy the API key and store it securely for authenticating your
-                    external service with TextBee.
+                    external service with textbee.
                   </p>
                 </div>
 

--- a/web/app/(app)/dashboard/(components)/get-started/inline-register-panel.tsx
+++ b/web/app/(app)/dashboard/(components)/get-started/inline-register-panel.tsx
@@ -35,7 +35,7 @@ export default function InlineRegisterPanel() {
       <div className='flex flex-col gap-4 sm:flex-row'>
         <ol className='flex-1 list-decimal space-y-2 pl-5 text-sm text-muted-foreground'>
           <li>
-            Install the TextBee app on your Android phone from{' '}
+            Install the textbee app on your Android phone from{' '}
             <a
               href={Routes.downloadAndroidApp}
               target='_blank'

--- a/web/app/(app)/dashboard/(components)/get-started/register-help-dialog.tsx
+++ b/web/app/(app)/dashboard/(components)/get-started/register-help-dialog.tsx
@@ -34,7 +34,7 @@ export default function RegisterHelpDialog({
         <ol className='mt-2 list-decimal space-y-3 pl-5 text-sm text-muted-foreground'>
           <li>Generate an API key in the step above (if you have not already).</li>
           <li>
-            Download the TextBee Android app from{' '}
+            Download the textbee Android app from{' '}
             <a
               href={Routes.downloadAndroidApp}
               target='_blank'

--- a/web/app/(app)/dashboard/(components)/get-started/steps.ts
+++ b/web/app/(app)/dashboard/(components)/get-started/steps.ts
@@ -50,7 +50,7 @@ export const STEPS: StepDef[] = [
   {
     id: 'download_app',
     label: 'Download the Android app',
-    description: 'Install TextBee on the Android phone that will send your SMS.',
+    description: 'Install textbee on the Android phone that will send your SMS.',
     doneDescription: 'Installed. Download it again if you are setting up another phone.',
     optional: true,
     timeEstimate: '~1 min',
@@ -70,7 +70,7 @@ export const STEPS: StepDef[] = [
   {
     id: 'register_device',
     label: 'Register your device',
-    description: 'Turn your phone into your SMS gateway: scan the QR code below with the TextBee app.',
+    description: 'Turn your phone into your SMS gateway: scan the QR code below with the textbee app.',
     doneDescription: 'Device registered. Register another the same way.',
     optional: false,
     timeEstimate: '~1 min',

--- a/web/app/download/page.tsx
+++ b/web/app/download/page.tsx
@@ -135,10 +135,10 @@ export default function DownloadPage() {
       <div className='container mx-auto max-w-5xl'>
         <div className='text-center mb-12'>
           <div className='inline-flex items-center rounded-full border px-3 py-1 text-sm bg-brand-50 dark:bg-brand-950 border-brand-200 dark:border-brand-800 text-brand-700 dark:text-brand-300 mb-4'>
-            <Download className='h-3.5 w-3.5 mr-2' /> Download TextBee
+            <Download className='h-3.5 w-3.5 mr-2' /> Download textbee
           </div>
           <h1 className='text-4xl font-bold tracking-tight text-foreground'>
-            Download TextBee App
+            Download textbee App
           </h1>
           <p className='mt-4 text-xl text-muted-foreground max-w-2xl mx-auto'>
             Transform your Android device into a powerful SMS gateway with our
@@ -170,11 +170,11 @@ export default function DownloadPage() {
                     <Skeleton className='h-8 w-48' />
                   ) : error ? (
                     <h2 className='text-2xl font-bold text-foreground'>
-                      TextBee App
+                      textbee App
                     </h2>
                   ) : (
                     <h2 className='text-2xl font-bold text-foreground'>
-                      {latestRelease?.name || 'TextBee App'}
+                      {latestRelease?.name || 'textbee App'}
                     </h2>
                   )}
                 </div>


### PR DESCRIPTION
Aligns branding with the lowercase convention: the product name is written textbee or textbee.dev everywhere, and PascalCase identifiers use Textbee.

- UI copy in the dashboard, download, and contribute pages
- Swagger title and description
- Email templates (including the TextBee.dev footers)
- Android notification and share strings
- Renames TextBeeUtils to TextbeeUtils and TextBeeTheme to TextbeeTheme, updates all references
- Gradle rootProject.name and MIGRATION.md references
- README: the compose setup creates a lowercase textbee database, so the doc now matches

No behavior changes. Android compileDevDebug builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized the product name to lowercase “textbee” across the Android app, web interface, documentation, API descriptions, and email communications.
  - Updated visible notification titles, sharing labels, onboarding instructions, contribution content, and download-page text.
  - Aligned database references and project naming with the lowercase branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->