### PR TITLE
Rebuild the transactional emails on a shared layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .cursor
 .claude/
 .omc/
+# Rendered email previews (pnpm preview:emails)
+api/tmp/

--- a/api/package.json
+++ b/api/package.json
@@ -19,7 +19,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "preview:emails": "ts-node -T scripts/preview-emails.ts"
   },
   "dependencies": {
     "@nest-modules/mailer": "^1.3.22",

--- a/api/package.json
+++ b/api/package.json
@@ -72,6 +72,7 @@
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "inline-css": "^2.6.3",
     "jest": "^30.2.0",
     "prettier": "^3.7.4",
     "source-map-support": "^0.5.21",

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.4
         version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.4.2)))(eslint@9.39.2(jiti@2.4.2))(prettier@3.7.4)
+      inline-css:
+        specifier: ^2.6.3
+        version: 2.6.3
       jest:
         specifier: ^30.2.0
         version: 30.2.0(@types/node@25.0.1)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))
@@ -164,7 +167,7 @@ importers:
         version: 7.1.4
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.0.1)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.25.8)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.25.8))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.0.1)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-loader:
         specifier: ^9.5.4
         version: 9.5.4(typescript@5.9.3)(webpack@5.103.0)
@@ -1058,6 +1061,7 @@ packages:
 
   '@nest-modules/mailer@1.3.22':
     resolution: {integrity: sha512-pWwM4RbLbyZvQ+Y55fMkzbFCGaJRyrQkZA6jxuRq+oVV/uT8UUtZc5bi4+w8rOPoLj7bqYvUAcvmtyXeMK9HbA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@nestjs/common': ^6.7.0 || ^7.0.0
       '@nestjs/core': ^6.7.0 || ^7.0.0
@@ -1709,6 +1713,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2357,6 +2362,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cron@4.3.5:
     resolution: {integrity: sha512-hKPP7fq1+OfyCqoePkKfVq7tNAdFwiQORr4lZUHwrf0tebC65fYEeWgOrXOL6prn1/fegGOdTfrM6e34PJfksg==}
@@ -2944,6 +2950,7 @@ packages:
   glob@10.4.2:
     resolution: {integrity: sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==}
     engines: {node: '>=16 || 14 >=14.18'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.0:
@@ -2952,11 +2959,11 @@ packages:
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3557,6 +3564,7 @@ packages:
 
   lodash.pick@4.4.0:
     resolution: {integrity: sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==}
+    deprecated: This package is deprecated. Use destructuring assignment syntax instead.
 
   lodash.reduce@4.6.0:
     resolution: {integrity: sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==}
@@ -4710,10 +4718,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -5498,35 +5508,77 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
+
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
 
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
+
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
 
+  '@babel/plugin-syntax-import-attributes@7.25.7(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
+
   '@babel/plugin-syntax-import-attributes@7.25.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)':
     dependencies:
@@ -5538,40 +5590,88 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
+
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
+
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
+
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
+
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.25.7
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.8)':
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/helper-plugin-utils': 7.25.7
+    optional: true
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)':
     dependencies:
@@ -5602,7 +5702,7 @@ snapshots:
       '@babel/parser': 7.25.8
       '@babel/template': 7.25.7
       '@babel/types': 7.25.8
-      debug: 4.3.7
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7398,6 +7498,20 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  babel-jest@30.2.0(@babel/core@7.25.8):
+    dependencies:
+      '@babel/core': 7.25.8
+      '@jest/transform': 30.2.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 7.0.1
+      babel-preset-jest: 30.2.0(@babel/core@7.25.8)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-jest@30.2.0(@babel/core@7.28.5):
     dependencies:
       '@babel/core': 7.28.5
@@ -7425,6 +7539,26 @@ snapshots:
     dependencies:
       '@types/babel__core': 7.20.5
 
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.25.8):
+    dependencies:
+      '@babel/core': 7.25.8
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.8)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.25.8)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.25.8)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.8)
+      '@babel/plugin-syntax-import-attributes': 7.25.7(@babel/core@7.25.8)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.8)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.8)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.8)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.8)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.8)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.8)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.8)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.8)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.8)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.25.8)
+    optional: true
+
   babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5):
     dependencies:
       '@babel/core': 7.28.5
@@ -7443,6 +7577,13 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5)
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5)
+
+  babel-preset-jest@30.2.0(@babel/core@7.25.8):
+    dependencies:
+      '@babel/core': 7.25.8
+      babel-plugin-jest-hoist: 30.2.0
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.25.8)
+    optional: true
 
   babel-preset-jest@30.2.0(@babel/core@7.28.5):
     dependencies:
@@ -8459,7 +8600,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       data-uri-to-buffer: 3.0.1
-      debug: 4.3.7
+      debug: 4.4.3
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
@@ -8629,7 +8770,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9653,7 +9794,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.3
       get-uri: 3.0.2
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -9792,7 +9933,7 @@ snapshots:
   proxy-agent@4.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.3
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       lru-cache: 5.1.1
@@ -10140,7 +10281,7 @@ snapshots:
   socks-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.3
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -10285,15 +10426,15 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.7
+      debug: 4.4.3
       fast-safe-stringify: 2.1.1
       form-data: 3.0.2
       formidable: 1.2.6
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.13.0
+      qs: 6.14.0
       readable-stream: 3.6.2
-      semver: 7.6.3
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10411,7 +10552,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.0.1)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.25.8)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.25.8))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.0.1)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -10425,10 +10566,10 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.25.8
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.28.5)
+      babel-jest: 30.2.0(@babel/core@7.25.8)
       jest-util: 30.2.0
 
   ts-loader@9.5.4(typescript@5.9.3)(webpack@5.103.0):

--- a/api/scripts/preview-emails.ts
+++ b/api/scripts/preview-emails.ts
@@ -1,0 +1,235 @@
+/**
+ * Renders every mail template to HTML you can open in a browser.
+ *
+ * Mirrors what MailerModule actually does at send time, including the
+ * inline-css pass, so what you see here is what lands in the inbox. Without
+ * this the only way to review an email was to send one.
+ *
+ *   pnpm preview:emails
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+import * as handlebars from 'handlebars'
+import inlineCss = require('inline-css')
+import {
+  buildEmailContent,
+  NOTIFICATION_SUBJECTS,
+} from '../src/billing/notification-content'
+
+const TEMPLATE_DIR = path.join(__dirname, '..', 'src', 'mail', 'templates')
+const PARTIAL_DIR = path.join(TEMPLATE_DIR, 'partials')
+const OUT_DIR = path.join(__dirname, '..', 'tmp', 'email-preview')
+
+const BRAND = 'textbee.dev'
+const YEAR = new Date().getFullYear()
+
+/** Meta as the billing service actually records it, per notification type. */
+const BILLING_META: Record<string, Record<string, any>> = {
+  daily_limit_approaching: { processedSmsToday: 42, dailyLimit: 50 },
+  monthly_limit_approaching: { processedSmsLastMonth: 4100, monthlyLimit: 5000 },
+  daily_limit_reached: { processedSmsToday: 50, dailyLimit: 50 },
+  monthly_limit_reached: { processedSmsLastMonth: 5000, monthlyLimit: 5000 },
+  bulk_sms_limit_reached: { attempted: 1200, bulkSendLimit: 50 },
+  device_limit_reached: { deviceLimit: 1 },
+  email_verification_required: {},
+}
+
+/** Realistic context per template, so the preview shows real-shaped content. */
+const SAMPLES: Record<string, Record<string, any>> = {
+  // Built through the real content builder, so the preview cannot drift from
+  // what actually sends. Every billing type is rendered, not just one.
+  'billing-notification': {
+    name: 'Alex',
+    ...buildEmailContent('monthly_limit_approaching', {
+      processedSmsLastMonth: 4100,
+      monthlyLimit: 5000,
+    }),
+  },
+  'verify-email': {
+    name: 'Alex',
+    verificationLink: 'https://app.textbee.dev/verify?token=sample-token-value',
+  },
+  'password-reset-request': {
+    name: 'Alex',
+    resetLink: 'https://app.textbee.dev/reset-password?token=sample-token-value',
+    otp: '482913',
+  },
+  'password-reset-success': { name: 'Alex' },
+  'customer-support-confirmation': {
+    name: 'Alex',
+    email: 'alex@example.com',
+    phone: '+1 555 0147',
+    category: 'Technical',
+    message:
+      'My gateway phone stopped sending after I restarted it. Messages sit in the dashboard but never leave the device.',
+  },
+  'account-deletion-request': {
+    name: 'Alex',
+    email: 'alex@example.com',
+    message: 'Moving to a different provider.',
+  },
+  'webhook-subscription-disabled': {
+    name: 'Alex',
+    title: 'A webhook was turned off',
+    subscriptionName: 'Order updates',
+    deliveryUrl: 'https://example.com/hooks/textbee',
+    failureCount: 42,
+    ctaLabel: 'Review webhooks',
+    ctaUrl: 'https://app.textbee.dev/dashboard/webhooks',
+  },
+  'webhook-auto-disable-admin-summary': {
+    title: 'Webhooks auto-disabled',
+    runAt: '2026-08-22 04:00 UTC',
+    count: 2,
+    rows: [
+      {
+        id: '66f1a2b3c4d5e6f708192a3b',
+        deliveryUrl: 'https://example.com/hooks/one',
+        failed: 120,
+        success: 3,
+        total: 123,
+        failureRate: '97.6',
+      },
+      {
+        id: '66f1a2b3c4d5e6f708192a3c',
+        deliveryUrl: 'https://example.org/webhook',
+        failed: 88,
+        success: 0,
+        total: 88,
+        failureRate: '100.0',
+      },
+    ],
+  },
+}
+
+function registerPartials() {
+  if (!fs.existsSync(PARTIAL_DIR)) return
+  for (const file of fs.readdirSync(PARTIAL_DIR).filter((f) => f.endsWith('.hbs'))) {
+    const name = path.basename(file, '.hbs')
+    handlebars.registerPartial(
+      name,
+      fs.readFileSync(path.join(PARTIAL_DIR, file), 'utf8'),
+    )
+  }
+}
+
+/**
+ * Cheap structural checks on the rendered output. These are the failures that
+ * are invisible when reading the template source: a stray tag that puts the
+ * whole document outside <html>, or a quoted font name that terminates its own
+ * style attribute once inline-css re-emits it with double quotes.
+ */
+function validate(name: string, html: string): string[] {
+  const problems: string[] = []
+  const count = (re: RegExp) => (html.match(re) ?? []).length
+
+  if (count(/<html[\s>]/gi) !== 1) {
+    problems.push(`${name}: expected exactly one <html> tag`)
+  }
+  if (count(/<head[\s>]/gi) !== 1) {
+    problems.push(`${name}: expected exactly one <head> tag`)
+  }
+  if (count(/<body[\s>]/gi) !== 1) {
+    problems.push(`${name}: expected exactly one <body> tag`)
+  }
+  if (/<html>\s*<\/html>/i.test(html)) {
+    problems.push(`${name}: empty <html></html> before the real document`)
+  }
+  const htmlAt = html.search(/<html[\s>]/i)
+  const headAt = html.search(/<head[\s>]/i)
+  if (htmlAt > -1 && headAt > -1 && headAt < htmlAt) {
+    problems.push(`${name}: <head> appears before <html>`)
+  }
+  // A style attribute that closed early leaves a bare token before the next
+  // attribute or the tag end, e.g. style="font:14px " Courier New", ...
+  for (const match of html.matchAll(/style="[^"]*"\s*[A-Za-z ]+"/g)) {
+    problems.push(
+      `${name}: style attribute terminated early near ${JSON.stringify(
+        match[0].slice(0, 60),
+      )}`,
+    )
+  }
+  if (!/display:\s*none/i.test(html)) {
+    problems.push(`${name}: no hidden preheader block`)
+  }
+  return problems
+}
+
+async function main() {
+  // Matches the adapter, which registers this helper on construction.
+  handlebars.registerHelper('concat', (...args: any[]) => {
+    args.pop()
+    return args.join('')
+  })
+  registerPartials()
+
+  fs.mkdirSync(OUT_DIR, { recursive: true })
+  const names = fs
+    .readdirSync(TEMPLATE_DIR)
+    .filter((f) => f.endsWith('.hbs'))
+    .map((f) => path.basename(f, '.hbs'))
+    .sort()
+
+  const rendered: string[] = []
+  const problems: string[] = []
+
+  // Every billing notification type gets its own preview, since they share one
+  // template but say completely different things.
+  const billingSource = fs.readFileSync(
+    path.join(TEMPLATE_DIR, 'billing-notification.hbs'),
+    'utf8',
+  )
+  const billingTemplate = handlebars.compile(billingSource)
+  for (const type of Object.keys(NOTIFICATION_SUBJECTS)) {
+    const context = {
+      brandName: BRAND,
+      year: YEAR,
+      name: 'Alex',
+      ...buildEmailContent(type, BILLING_META[type] ?? {}),
+    }
+    const inlined = await inlineCss(billingTemplate(context), { url: ' ' })
+    const label = `billing-${type.replace(/_/g, '-')}`
+    fs.writeFileSync(path.join(OUT_DIR, `${label}.html`), inlined)
+    rendered.push(label)
+    problems.push(...validate(label, inlined))
+  }
+
+  for (const name of names) {
+    const source = fs.readFileSync(path.join(TEMPLATE_DIR, `${name}.hbs`), 'utf8')
+    const context = {
+      brandName: BRAND,
+      year: YEAR,
+      currentYear: YEAR,
+      ...(SAMPLES[name] ?? {}),
+    }
+    const html = handlebars.compile(source)(context)
+    // The adapter inlines CSS before sending, so the preview must too.
+    const inlined = await inlineCss(html, { url: ' ' })
+    fs.writeFileSync(path.join(OUT_DIR, `${name}.html`), inlined)
+    rendered.push(name)
+    if (!SAMPLES[name]) console.warn(`  no sample context for ${name}`)
+    problems.push(...validate(name, inlined))
+  }
+
+  if (problems.length) {
+    console.error('\nStructural problems found:')
+    for (const problem of problems) console.error(`  ${problem}`)
+    process.exitCode = 1
+  }
+
+  const index = `<!doctype html><meta charset="utf-8"><title>textbee email previews</title>
+<style>body{font:16px/1.6 system-ui,sans-serif;max-width:40rem;margin:3rem auto;padding:0 1rem}
+h1{font-size:1.25rem}li{margin:.35rem 0}a{color:#EA580C}</style>
+<h1>textbee email previews</h1>
+<p>Rendered ${rendered.length} templates at ${new Date().toISOString()}.</p>
+<ul>${rendered.map((n) => `<li><a href="./${n}.html">${n}</a></li>`).join('')}</ul>`
+  fs.writeFileSync(path.join(OUT_DIR, 'index.html'), index)
+
+  console.log(`Rendered ${rendered.length} templates`)
+  console.log(`Open ${path.join(OUT_DIR, 'index.html')}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/api/src/billing/billing-notifications.listener.ts
+++ b/api/src/billing/billing-notifications.listener.ts
@@ -3,6 +3,7 @@ import { OnEvent } from '@nestjs/event-emitter'
 import { InjectModel } from '@nestjs/mongoose'
 import { Model, Types } from 'mongoose'
 import { MailService } from '../mail/mail.service'
+import { buildEmailContent, subjectForType } from './notification-content'
 import {
   BillingNotification,
   BillingNotificationDocument,
@@ -39,25 +40,23 @@ export class BillingNotificationsListener {
       return
     }
 
-    const subject = this.subjectForType(payload.type, payload.title)
-    const ctaUrlBase = process.env.FRONTEND_URL || 'https://app.textbee.dev'
-    const isEmailVerification = payload.type === 'email_verification_required'
-    const ctaUrl = isEmailVerification
-      ? `${ctaUrlBase}/dashboard/account`
-      : 'https://textbee.dev/#pricing'
-    const ctaLabel = isEmailVerification ? 'Verify your email' : 'View plans & pricing'
+    const subject = subjectForType(payload.type, payload.title)
+    const content = buildEmailContent(
+      payload.type,
+      payload.meta,
+      payload.title,
+      payload.message,
+    )
 
     await this.mailService.sendEmailFromTemplate({
       to: user.email,
       subject,
       template: 'billing-notification',
       context: {
+        ...content,
         name: user.name?.split(' ')?.[0] || 'there',
-        title: payload.title,
-        message: payload.message,
-        ctaLabel,
-        ctaUrl,
         brandName: 'textbee.dev',
+        year: new Date().getFullYear(),
       },
       from: undefined,
     })
@@ -68,22 +67,4 @@ export class BillingNotificationsListener {
     )
   }
 
-  private subjectForType(type: string, fallback: string) {
-    switch (type) {
-      case 'daily_limit_reached':
-        return 'Daily SMS limit reached — action required'
-      case 'monthly_limit_reached':
-        return 'Monthly SMS limit reached — action required'
-      case 'bulk_sms_limit_reached':
-        return 'Bulk send limit exceeded'
-      case 'daily_limit_approaching':
-        return 'Heads up: daily usage nearing your limit'
-      case 'monthly_limit_approaching':
-        return 'Heads up: monthly usage nearing your limit'
-      case 'email_verification_required':
-        return 'Verify your email to keep using textbee'
-      default:
-        return fallback || 'Account notification'
-    }
-  }
 }

--- a/api/src/billing/billing.controller.ts
+++ b/api/src/billing/billing.controller.ts
@@ -189,7 +189,7 @@ export class BillingController {
       case 'subscription.canceled':
         console.log('polar webhook event', payload.type)
         console.log(payload)
-        // Cancellation is SCHEDULED here — access continues until period end.
+        // Cancellation is SCHEDULED here: access continues until period end.
         // Record the intent without downgrading; the actual downgrade happens
         // on "subscription.revoked".
         await this.billingService.cancelSubscription({
@@ -206,7 +206,7 @@ export class BillingController {
       case 'subscription.revoked':
         console.log('polar webhook event', payload.type)
         console.log(payload)
-        // Access should actually end now — perform the real downgrade.
+        // Access should actually end now, so perform the real downgrade.
         await this.billingService.revokeSubscription({
           userId: (payload.data?.metadata?.userId ||
             payload.data?.customer?.externalId) as string,

--- a/api/src/billing/billing.service.ts
+++ b/api/src/billing/billing.service.ts
@@ -1020,17 +1020,17 @@ export class BillingService {
 
         if (dailyExceeded) {
           hasReachedLimit = true
-          message = `Daily SMS limit reached — you've used your full daily allocation. ${Math.max(0, effectiveLimits.dailyLimit - processedSmsToday)} messages remain for today. Upgrade to increase your daily capacity or try again tomorrow.`
+          message = `You have sent all ${effectiveLimits.dailyLimit} messages your plan allows today. Sending resumes automatically when the allowance resets at midnight, or move up a plan to carry on now.`
         }
 
         if (monthlyExceeded) {
           hasReachedLimit = true
-          message = `Monthly SMS limit reached — you've used this billing period's allocation. Upgrade to continue sending immediately, or wait for the next billing period.`
+          message = `You have sent all ${effectiveLimits.monthlyLimit} messages included in your plan this period. Sending resumes automatically at the next billing period, or move up a plan to carry on now.`
         }
 
         if (bulkExceeded) {
           hasReachedLimit = true
-          message = `Bulk send limit exceeded — your plan allows up to ${effectiveLimits.bulkSendLimit} messages per batch. Split your send into smaller batches or upgrade your plan.`
+          message = `That batch had ${value} recipients and your plan allows ${effectiveLimits.bulkSendLimit} per batch, so nothing was sent. Split it into smaller batches to send it as it is, or move up a plan for a larger batch size.`
         }
       }
 

--- a/api/src/billing/billing.service.ts
+++ b/api/src/billing/billing.service.ts
@@ -117,7 +117,7 @@ export class BillingService {
                 userId: user._id,
                 type: BillingNotificationType.MONTHLY_LIMIT_APPROACHING,
                 title: "You're nearing this month's SMS limit",
-                message: `You've used ${Math.round(monthlyPct * 100)}% of this month's SMS allocation. ${effectiveLimits.monthlyLimit - processedSmsLastMonth} messages remain this billing period. Upgrade to increase your monthly capacity.`,
+                message: `You've used ${Math.round(monthlyPct * 100)}% of the messages your plan allows over the last 30 days. ${effectiveLimits.monthlyLimit - processedSmsLastMonth} are left.`,
                 meta: {
                   processedSmsLastMonth,
                   monthlyLimit: effectiveLimits.monthlyLimit,
@@ -195,7 +195,7 @@ export class BillingService {
               userId: user._id,
               type: BillingNotificationType.MONTHLY_LIMIT_APPROACHING,
               title: "You're nearing this month's SMS limit",
-              message: `You've used ${Math.round(monthlyPct * 100)}% of this month's SMS allocation. ${effectiveLimits.monthlyLimit - processedSmsLastMonth} messages remain this billing period. Upgrade to increase your monthly capacity.`,
+              message: `You've used ${Math.round(monthlyPct * 100)}% of the messages your plan allows over the last 30 days. ${effectiveLimits.monthlyLimit - processedSmsLastMonth} are left.`,
               meta: {
                 processedSmsLastMonth,
                 monthlyLimit: effectiveLimits.monthlyLimit,
@@ -1025,7 +1025,7 @@ export class BillingService {
 
         if (monthlyExceeded) {
           hasReachedLimit = true
-          message = `You have sent all ${effectiveLimits.monthlyLimit} messages included in your plan this period. Sending resumes automatically at the next billing period, or move up a plan to carry on now.`
+          message = `You have sent all ${effectiveLimits.monthlyLimit} messages your plan allows over the last 30 days. Usage is counted on a rolling window, so sending resumes as your earliest messages pass that mark, or move up a plan to carry on now.`
         }
 
         if (bulkExceeded) {

--- a/api/src/billing/notification-content.spec.ts
+++ b/api/src/billing/notification-content.spec.ts
@@ -54,6 +54,25 @@ describe('notification content', () => {
   })
 
   describe('approaching a limit', () => {
+    it('describes the monthly counter as a rolling window, not a reset', () => {
+      // processedSmsLastMonth counts from one month before now, so telling a
+      // user their allowance resets at renewal would be wrong.
+      for (const type of [
+        BillingNotificationType.MONTHLY_LIMIT_APPROACHING,
+        BillingNotificationType.MONTHLY_LIMIT_REACHED,
+      ]) {
+        const content = buildEmailContent(type, {
+          processedSmsLastMonth: 5000,
+          monthlyLimit: 5000,
+        })
+        const text = [content.message, content.resetNote, content.preheader]
+          .filter(Boolean)
+          .join(' ')
+        expect(text).toMatch(/30 day|age out|ages out/i)
+        expect(text).not.toMatch(/billing period/i)
+      }
+    })
+
     it('reports what is left, not just what is used', () => {
       const content = buildEmailContent(
         BillingNotificationType.MONTHLY_LIMIT_APPROACHING,
@@ -63,7 +82,7 @@ describe('notification content', () => {
       expect(content.message).toContain('5,000')
       expect(content.message).toContain('900')
       expect(content.usage).toEqual({
-        label: 'Messages this period',
+        label: 'Messages in the last 30 days',
         used: '4,100',
         limit: '5,000',
         percent: 82,

--- a/api/src/billing/notification-content.spec.ts
+++ b/api/src/billing/notification-content.spec.ts
@@ -1,0 +1,125 @@
+import {
+  buildEmailContent,
+  NOTIFICATION_SUBJECTS,
+  subjectForType,
+} from './notification-content'
+import { BillingNotificationType } from './schemas/billing-notification.schema'
+
+describe('notification content', () => {
+  it('has a subject for every notification type', () => {
+    for (const type of Object.values(BillingNotificationType)) {
+      expect(NOTIFICATION_SUBJECTS[type]).toBeTruthy()
+    }
+  })
+
+  it('falls back rather than inventing a subject for an unknown type', () => {
+    expect(subjectForType('not_a_real_type', 'Stored title')).toBe('Stored title')
+    expect(subjectForType('not_a_real_type')).toBe('Account notification')
+  })
+
+  it('never uses an em dash or en dash in user-facing copy', () => {
+    for (const type of Object.values(BillingNotificationType)) {
+      const content = buildEmailContent(type, {
+        processedSmsToday: 42,
+        processedSmsLastMonth: 4100,
+        dailyLimit: 50,
+        monthlyLimit: 5000,
+        bulkSendLimit: 50,
+        deviceLimit: 1,
+        attempted: 1200,
+      })
+      const text = [
+        NOTIFICATION_SUBJECTS[type],
+        content.title,
+        content.preheader,
+        content.message,
+        content.resetNote,
+        content.footnote,
+        content.benefitsTitle,
+        ...(content.benefits ?? []),
+      ]
+        .filter(Boolean)
+        .join(' ')
+      expect(text).not.toMatch(/[–—]/)
+    }
+  })
+
+  it('sends every upgrade CTA to the pricing page, not an anchor', () => {
+    for (const type of Object.values(BillingNotificationType)) {
+      const { ctaUrl, ctaLabel } = buildEmailContent(type, {})
+      expect(ctaLabel).toBeTruthy()
+      expect(ctaUrl).toMatch(/^https:\/\//)
+      expect(ctaUrl).not.toContain('#pricing')
+    }
+  })
+
+  describe('approaching a limit', () => {
+    it('reports what is left, not just what is used', () => {
+      const content = buildEmailContent(
+        BillingNotificationType.MONTHLY_LIMIT_APPROACHING,
+        { processedSmsLastMonth: 4100, monthlyLimit: 5000 },
+      )
+      expect(content.message).toContain('4,100')
+      expect(content.message).toContain('5,000')
+      expect(content.message).toContain('900')
+      expect(content.usage).toEqual({
+        label: 'Messages this period',
+        used: '4,100',
+        limit: '5,000',
+        percent: 82,
+      })
+    })
+
+    it('offers the free way out before the paid one', () => {
+      const content = buildEmailContent(
+        BillingNotificationType.DAILY_LIMIT_REACHED,
+        { dailyLimit: 50 },
+      )
+      expect(content.resetNote).toMatch(/automatically/i)
+      // the upgrade is present, but framed as the alternative
+      expect(content.benefitsTitle).toMatch(/if you need/i)
+    })
+  })
+
+  describe('bulk limit', () => {
+    const content = buildEmailContent(
+      BillingNotificationType.BULK_SMS_LIMIT_REACHED,
+      { attempted: 1200, bulkSendLimit: 50 },
+    )
+
+    it('says plainly that nothing was sent', () => {
+      expect(content.message).toContain('Nothing was sent')
+      expect(content.message).toContain('1,200')
+      expect(content.message).toContain('50')
+    })
+
+    it('leads with splitting the batch, which costs nothing', () => {
+      expect(content.resetNote).toMatch(/splitting/i)
+      expect(content.resetNote).toMatch(/no extra cost/i)
+    })
+
+    it('shows no usage bar, since attempted is not consumption', () => {
+      // A full bar here would imply the quota was spent, which it was not.
+      expect(content.usage).toBeUndefined()
+    })
+  })
+
+  describe('usage percentages', () => {
+    it('clamps past the limit rather than overflowing the bar', () => {
+      const content = buildEmailContent(
+        BillingNotificationType.MONTHLY_LIMIT_APPROACHING,
+        { processedSmsLastMonth: 9999, monthlyLimit: 5000 },
+      )
+      expect(content.usage?.percent).toBe(100)
+    })
+
+    it('survives a missing or zero limit without dividing by zero', () => {
+      const content = buildEmailContent(
+        BillingNotificationType.DAILY_LIMIT_APPROACHING,
+        { processedSmsToday: 10 },
+      )
+      expect(content.usage?.percent).toBe(100)
+      expect(content.message).toContain('10')
+    })
+  })
+})

--- a/api/src/billing/notification-content.ts
+++ b/api/src/billing/notification-content.ts
@@ -1,0 +1,235 @@
+import { BillingNotificationType } from './schemas/billing-notification.schema'
+
+/**
+ * Subjects and email bodies for billing notifications, in one place.
+ *
+ * This used to live in two duplicated `subjectForType` maps plus message
+ * strings built at four call sites, which had already drifted. The stored
+ * notification keeps its own short title and message for the in-app list; this
+ * module owns what the email says.
+ *
+ * Copy principles, since these are the emails that decide whether someone
+ * upgrades:
+ * - Lead with the person's situation, not the policy.
+ * - Give the way out that costs nothing first, then the paid one. Someone who
+ *   cannot pay still needs to know they can wait or split the batch.
+ * - Never scold. Hitting a limit is the product working, not the user erring.
+ * - The approaching emails are the real moment: the user is still succeeding
+ *   and can act calmly. The reached emails arrive when they are already stuck.
+ */
+
+const PRICING_URL = 'https://textbee.dev/pricing'
+const ACCOUNT_URL = 'https://app.textbee.dev/dashboard/account'
+
+export const NOTIFICATION_SUBJECTS: Record<string, string> = {
+  [BillingNotificationType.DAILY_LIMIT_APPROACHING]:
+    "You've used most of today's messages",
+  [BillingNotificationType.MONTHLY_LIMIT_APPROACHING]:
+    "You've used most of this month's messages",
+  [BillingNotificationType.DAILY_LIMIT_REACHED]:
+    "You've hit today's message limit",
+  [BillingNotificationType.MONTHLY_LIMIT_REACHED]:
+    "You've hit this month's message limit",
+  [BillingNotificationType.BULK_SMS_LIMIT_REACHED]:
+    'That batch was larger than your plan allows',
+  [BillingNotificationType.DEVICE_LIMIT_REACHED]:
+    "You've connected all the devices your plan allows",
+  [BillingNotificationType.EMAIL_VERIFICATION_REQUIRED]:
+    'Verify your email to keep sending',
+}
+
+export function subjectForType(type: string, fallback?: string): string {
+  return NOTIFICATION_SUBJECTS[type] || fallback || 'Account notification'
+}
+
+export interface NotificationEmailContent {
+  title: string
+  preheader: string
+  message: string
+  usage?: { label: string; used: string; limit: string; percent: number }
+  resetNote?: string
+  benefitsTitle?: string
+  benefits?: string[]
+  footnote?: string
+  ctaLabel: string
+  ctaUrl: string
+}
+
+const n = (value: unknown): number => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const fmt = (value: unknown): string => n(value).toLocaleString('en-US')
+
+/** Clamped so a bar can never overflow its track when usage passes the limit. */
+const pct = (used: unknown, limit: unknown): number => {
+  const total = n(limit)
+  if (total <= 0) return 100
+  return Math.min(100, Math.max(0, Math.round((n(used) / total) * 100)))
+}
+
+const MORE_VOLUME = [
+  'A higher monthly message allowance',
+  'No daily cap, so a busy day does not stop you',
+  'Connect more Android devices to share the load',
+]
+
+export function buildEmailContent(
+  type: string,
+  meta: Record<string, any> = {},
+  fallbackTitle = '',
+  fallbackMessage = '',
+): NotificationEmailContent {
+  switch (type) {
+    case BillingNotificationType.DAILY_LIMIT_APPROACHING: {
+      const used = meta.processedSmsToday
+      const limit = meta.dailyLimit
+      const left = Math.max(0, n(limit) - n(used))
+      return {
+        title: "You've used most of today's messages",
+        preheader: `${fmt(used)} of ${fmt(limit)} sent today, ${fmt(left)} left.`,
+        message: `You have sent ${fmt(used)} of the ${fmt(limit)} messages your plan allows per day, so ${fmt(left)} are left before sending pauses.`,
+        usage: {
+          label: 'Messages sent today',
+          used: fmt(used),
+          limit: fmt(limit),
+          percent: pct(used, limit),
+        },
+        resetNote:
+          'Your daily allowance resets at midnight, so you can also just pick this up tomorrow.',
+        benefitsTitle: 'If you need the headroom today',
+        benefits: MORE_VOLUME,
+        ctaLabel: 'See plans',
+        ctaUrl: PRICING_URL,
+      }
+    }
+
+    case BillingNotificationType.MONTHLY_LIMIT_APPROACHING: {
+      const used = meta.processedSmsLastMonth
+      const limit = meta.monthlyLimit
+      const left = Math.max(0, n(limit) - n(used))
+      return {
+        title: "You've used most of this month's messages",
+        preheader: `${fmt(used)} of ${fmt(limit)} sent this period, ${fmt(left)} left.`,
+        message: `You have sent ${fmt(used)} of the ${fmt(limit)} messages included in your plan this period, so ${fmt(left)} are left.`,
+        usage: {
+          label: 'Messages this period',
+          used: fmt(used),
+          limit: fmt(limit),
+          percent: pct(used, limit),
+        },
+        resetNote:
+          'Your allowance resets at the start of the next billing period.',
+        benefitsTitle: 'If you would rather not wait',
+        benefits: MORE_VOLUME,
+        ctaLabel: 'See plans',
+        ctaUrl: PRICING_URL,
+      }
+    }
+
+    case BillingNotificationType.DAILY_LIMIT_REACHED: {
+      const limit = meta.dailyLimit
+      return {
+        title: "You've hit today's message limit",
+        preheader: `Sending resumes at midnight, or move up a plan for more headroom.`,
+        message: `You have sent all ${fmt(limit)} messages your plan allows today, so further sends will not go out until the allowance resets.`,
+        usage: {
+          label: 'Messages sent today',
+          used: fmt(limit),
+          limit: fmt(limit),
+          percent: 100,
+        },
+        resetNote:
+          'Sending starts again automatically at midnight. You do not need to do anything.',
+        benefitsTitle: 'If you need to keep sending now',
+        benefits: MORE_VOLUME,
+        ctaLabel: 'See plans',
+        ctaUrl: PRICING_URL,
+      }
+    }
+
+    case BillingNotificationType.MONTHLY_LIMIT_REACHED: {
+      const limit = meta.monthlyLimit
+      return {
+        title: "You've hit this month's message limit",
+        preheader:
+          'Sending resumes next billing period, or move up a plan to carry on now.',
+        message: `You have sent all ${fmt(limit)} messages included in your plan this period, so further sends will not go out until it resets.`,
+        usage: {
+          label: 'Messages this period',
+          used: fmt(limit),
+          limit: fmt(limit),
+          percent: 100,
+        },
+        resetNote:
+          'Sending starts again automatically at the next billing period.',
+        benefitsTitle: 'If you need to keep sending now',
+        benefits: MORE_VOLUME,
+        ctaLabel: 'See plans',
+        ctaUrl: PRICING_URL,
+      }
+    }
+
+    case BillingNotificationType.BULK_SMS_LIMIT_REACHED: {
+      const limit = meta.bulkSendLimit
+      const attempted = meta.attempted
+      return {
+        title: 'That batch was larger than your plan allows',
+        preheader: `Split it into smaller batches, or move up a plan.`,
+        message: `You tried to send to ${fmt(attempted)} recipients in one request, and your plan allows ${fmt(limit)} per batch. Nothing was sent.`,
+        // Deliberately no usage bar: this is attempted against a maximum, not
+        // consumption against an allowance, and a full bar would imply the
+        // quota is spent when it is not.
+        resetNote: `Splitting the file into batches of ${fmt(limit)} or fewer will send it as it is, at no extra cost.`,
+        benefitsTitle: 'Or move up a plan for',
+        benefits: [
+          'A larger batch size, so a whole list goes in one request',
+          'A higher monthly message allowance',
+          'Connect more Android devices to share the load',
+        ],
+        footnote:
+          'Whatever the batch size, your phone sends one message at a time, so a large campaign is delivered steadily rather than all at once.',
+        ctaLabel: 'See plans',
+        ctaUrl: PRICING_URL,
+      }
+    }
+
+    case BillingNotificationType.DEVICE_LIMIT_REACHED: {
+      const limit = meta.deviceLimit
+      return {
+        title: "You've connected all the devices your plan allows",
+        preheader:
+          'Remove a device you no longer use, or move up a plan for more.',
+        message: `Your plan covers ${fmt(limit)} active device${n(limit) === 1 ? '' : 's'}, and they are all in use. Removing one you no longer need frees the slot straight away.`,
+        benefitsTitle: 'More devices also means',
+        benefits: [
+          'Sends spread across several phones instead of queueing on one',
+          'A spare gateway if one phone goes offline',
+        ],
+        ctaLabel: 'See plans',
+        ctaUrl: PRICING_URL,
+      }
+    }
+
+    case BillingNotificationType.EMAIL_VERIFICATION_REQUIRED: {
+      return {
+        title: 'Verify your email to keep sending',
+        preheader: 'One click confirms the address on your account.',
+        message:
+          'Confirm the email address on your account and everything carries on as normal. It takes one click.',
+        ctaLabel: 'Verify my email',
+        ctaUrl: ACCOUNT_URL,
+      }
+    }
+
+    default:
+      return {
+        title: fallbackTitle || 'Account notification',
+        preheader: fallbackMessage.slice(0, 120),
+        message: fallbackMessage,
+        ctaLabel: 'Open dashboard',
+        ctaUrl: 'https://app.textbee.dev/dashboard',
+      }
+  }
+}

--- a/api/src/billing/notification-content.ts
+++ b/api/src/billing/notification-content.ts
@@ -111,16 +111,18 @@ export function buildEmailContent(
       const left = Math.max(0, n(limit) - n(used))
       return {
         title: "You've used most of this month's messages",
-        preheader: `${fmt(used)} of ${fmt(limit)} sent this period, ${fmt(left)} left.`,
-        message: `You have sent ${fmt(used)} of the ${fmt(limit)} messages included in your plan this period, so ${fmt(left)} are left.`,
+        preheader: `${fmt(used)} of ${fmt(limit)} sent in the last 30 days, ${fmt(left)} left.`,
+        message: `You have sent ${fmt(used)} of the ${fmt(limit)} messages your plan allows, counted over the last 30 days, so ${fmt(left)} are left.`,
         usage: {
-          label: 'Messages this period',
+          label: 'Messages in the last 30 days',
           used: fmt(used),
           limit: fmt(limit),
           percent: pct(used, limit),
         },
+        // Rolling window, not a billing period: capacity returns gradually as
+        // individual messages age past 30 days, not all at once on renewal.
         resetNote:
-          'Your allowance resets at the start of the next billing period.',
+          'This is a rolling 30 day window rather than a monthly reset, so capacity frees up gradually as your earliest messages age out.',
         benefitsTitle: 'If you would rather not wait',
         benefits: MORE_VOLUME,
         ctaLabel: 'See plans',
@@ -154,16 +156,16 @@ export function buildEmailContent(
       return {
         title: "You've hit this month's message limit",
         preheader:
-          'Sending resumes next billing period, or move up a plan to carry on now.',
-        message: `You have sent all ${fmt(limit)} messages included in your plan this period, so further sends will not go out until it resets.`,
+          'Capacity returns as older messages age out, or move up a plan to carry on now.',
+        message: `You have sent all ${fmt(limit)} messages your plan allows over the last 30 days, so further sends will not go out until some of that usage ages out.`,
         usage: {
-          label: 'Messages this period',
+          label: 'Messages in the last 30 days',
           used: fmt(limit),
           limit: fmt(limit),
           percent: 100,
         },
         resetNote:
-          'Sending starts again automatically at the next billing period.',
+          'Usage is counted over a rolling 30 day window, so sending starts again on its own as your earliest messages pass that mark.',
         benefitsTitle: 'If you need to keep sending now',
         benefits: MORE_VOLUME,
         ctaLabel: 'See plans',

--- a/api/src/billing/queue/billing-notifications.processor.ts
+++ b/api/src/billing/queue/billing-notifications.processor.ts
@@ -3,6 +3,7 @@ import { InjectModel } from '@nestjs/mongoose'
 import { Job } from 'bull'
 import { Model, Types } from 'mongoose'
 import { MailService } from '../../mail/mail.service'
+import { buildEmailContent, subjectForType } from '../notification-content'
 import { User, UserDocument } from '../../users/schemas/user.schema'
 import {
   BillingNotification,
@@ -49,25 +50,25 @@ export class BillingNotificationsProcessor {
       return
     }
 
-    const subject = this.subjectForType(payload.type, payload.title)
-    const ctaUrlBase = process.env.FRONTEND_URL || 'https://app.textbee.dev'
-    const isEmailVerification = payload.type === 'email_verification_required'
-    const ctaUrl = isEmailVerification
-      ? `${ctaUrlBase}/dashboard/account`
-      : 'https://textbee.dev/#pricing'
-    const ctaLabel = isEmailVerification ? 'Verify your email' : 'View plans & pricing'
+    const subject = subjectForType(payload.type, payload.title)
+    // The stored title and message serve the in-app list. The email builds its
+    // own copy from the type and the figures already captured in meta.
+    const content = buildEmailContent(
+      payload.type,
+      payload.meta,
+      payload.title,
+      payload.message,
+    )
 
     await this.mailService.sendEmailFromTemplate({
       to: user.email,
       subject,
       template: 'billing-notification',
       context: {
+        ...content,
         name: user.name?.split(' ')?.[0] || 'there',
-        title: payload.title,
-        message: payload.message,
-        ctaLabel,
-        ctaUrl,
         brandName: 'textbee.dev',
+        year: new Date().getFullYear(),
       },
       from: undefined,
     })
@@ -91,24 +92,6 @@ export class BillingNotificationsProcessor {
     return hours * 60 * 60 * 1000
   }
 
-  private subjectForType(type: string, fallback: string) {
-    switch (type) {
-      case 'daily_limit_reached':
-        return 'Daily SMS limit reached — action required'
-      case 'monthly_limit_reached':
-        return 'Monthly SMS limit reached — action required'
-      case 'bulk_sms_limit_reached':
-        return 'Bulk send limit exceeded'
-      case 'daily_limit_approaching':
-        return 'Heads up: daily usage nearing your limit'
-      case 'monthly_limit_approaching':
-        return 'Heads up: monthly usage nearing your limit'
-      case 'email_verification_required':
-        return 'Verify your email to keep using textbee'
-      default:
-        return fallback || 'Account notification'
-    }
-  }
 }
 
 

--- a/api/src/mail/mail.module.ts
+++ b/api/src/mail/mail.module.ts
@@ -18,7 +18,16 @@ import { MailService } from './mail.service'
           strict: true,
         },
       },
-    }),
+      // Top level, not under `template`: the adapter reads partials from
+      // MailerOptions.options, and every template is a block inside the shared
+      // email-layout partial.
+      options: {
+        partials: {
+          dir: join(__dirname, 'templates', 'partials'),
+          options: { strict: true },
+        },
+      },
+    } as any),
   ],
   providers: [MailService],
   exports: [MailService],

--- a/api/src/mail/templates/account-deletion-request.hbs
+++ b/api/src/mail/templates/account-deletion-request.hbs
@@ -1,43 +1,37 @@
-<html lang='en'>
-  <head>
-    <meta charset='UTF-8' />
-    <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-    <title>Account Deletion Request</title>
-    <style>
-      body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
-      h1 { color: #dc2626; }
-      .notice { background: #fee2e2; border-left: 4px solid #dc2626; padding: 15px; margin: 15px 0; }
-      .cancel { background: #e0f2fe; border: 2px solid #0284c7; padding: 15px; margin: 20px 0; text-align: center; }
-      .footer { text-align: center; font-size: 14px; color: #6b7280; margin-top: 30px; padding-top: 20px; border-top: 1px solid #e5e7eb; }
-    </style>
-  </head>
-  <body>
-    <h1>Account Deletion Request</h1>
+{{#> email-layout title='Your account is scheduled for deletion' preheader='Reply within 7 days if you want to keep it.'}}
+  <p style='margin:0 0 14px 0;'>Hi {{name}},</p>
 
-    <p>Hello {{name}},</p>
+  <p style='margin:0 0 4px 0;'>
+    We received your request to delete the textbee account for {{email}}.
+    Sorry to see you go.
+  </p>
 
-    <p>We have received your request to delete your textbee account. We're sorry to see you go.</p>
+  {{#> email-note}}
+    <strong style='color:#111827;'>What happens next</strong>
+    <table role='presentation' cellpadding='0' cellspacing='0' border='0' style='margin-top:8px;'>
+      <tr>
+        <td valign='top' style='padding:0 8px 6px 0; color:#EA580C;'>&bull;</td>
+        <td style='padding:0 0 6px 0;'>Deletion is processed within 7 days.</td>
+      </tr>
+      <tr>
+        <td valign='top' style='padding:0 8px 6px 0; color:#EA580C;'>&bull;</td>
+        <td style='padding:0 0 6px 0;'>You can still sign in until then.</td>
+      </tr>
+      <tr>
+        <td valign='top' style='padding:0 8px 0 0; color:#EA580C;'>&bull;</td>
+        <td>Once processed, your data is removed permanently and cannot be recovered.</td>
+      </tr>
+    </table>
+  {{/email-note}}
 
-    <div class='notice'>
-      <p><strong>Important:</strong> Your account has been marked for deletion and will be processed within 7 days. During this period:</p>
-      <ul>
-        <li>You can still log in and access your account until the deletion is completed</li>
-        <li>After the deletion is complete, all your data will be permanently removed</li>
-        <li>This action cannot be undone once processed</li>
-      </ul>
-    </div>
+  {{#if message}}
+    <p style='margin:20px 0 0 0; font:14px/1.6 Arial, Helvetica, sans-serif; color:#4b5563;'>
+      Reason you gave: {{message}}
+    </p>
+  {{/if}}
 
-    <p><strong>Reason for deletion:</strong> {{#if message}}{{message}}{{else}}No reason provided{{/if}}</p>
-
-    <p><strong>Account:</strong> {{name}} ({{email}})</p>
-
-    <div class='cancel'>
-      <h3 style='color: #0284c7; margin-top: 0;'>Changed Your Mind?</h3>
-      <p>If you didn't request this deletion or want to keep your account, simply reply to this email and we'll immediately stop the deletion process.</p>
-    </div>
-
-    <div class='footer'>
-      <p>&copy; {{currentYear}} textbee.dev.</p>
-    </div>
-  </body>
-</html>
+  <p style='margin:20px 0 0 0;'>
+    <strong style='color:#111827;'>Changed your mind?</strong>
+    Reply to this email and we will stop the deletion.
+  </p>
+{{/email-layout}}

--- a/api/src/mail/templates/billing-notification.hbs
+++ b/api/src/mail/templates/billing-notification.hbs
@@ -1,88 +1,29 @@
-<html lang='en' xmlns:v='urn:schemas-microsoft-com:vml' xmlns:o='urn:schemas-microsoft-com:office:office'>
-  <head>
-    <meta charset='utf-8' />
-    <meta name='viewport' content='width=device-width, initial-scale=1' />
-    <meta http-equiv='x-ua-compatible' content='ie=edge' />
-    <title>{{title}} • {{brandName}}</title>
-    <style>
-      .preheader { display:none !important; visibility:hidden; opacity:0; color:transparent; height:0; width:0; overflow:hidden; mso-hide:all; }
-      @media screen and (max-width: 600px) { .container { width:100% !important; } .stack { display:block !important; width:100% !important; } .p-sm { padding:16px !important; } .text-center-sm { text-align:center !important; } .hide-sm { display:none !important; } }
-    </style>
-    <!--[if mso]>
-      <style type="text/css"> body, table, td, a { font-family: Helvetica, Arial, sans-serif !important; } </style>
-    <![endif]-->
-  </head>
-  <body style='margin:0; padding:0; background:#f7f9fc;'>
-    <div class='preheader'>Important account update from {{brandName}}</div>
-    <table role='presentation' cellpadding='0' cellspacing='0' border='0' width='100%' class='email-bg' style='background:#f7f9fc;'>
-      <tr>
-        <td align='center' style='padding:24px;'>
-          <table role='presentation' cellpadding='0' cellspacing='0' border='0' width='600' class='container' style='width:600px; max-width:600px;'>
-            <tr>
-              <td style='padding:12px 16px 0 16px;'>
-                <table role='presentation' width='100%' cellspacing='0' cellpadding='0' border='0'>
-                  <tr>
-                    <td class='stack' valign='middle' style='padding:8px 0;'>
-                      <table role='presentation' cellspacing='0' cellpadding='0' border='0'>
-                        <tr>
-                          <td valign='middle' style='padding-right:10px;'>
-                            <img src='https://textbee.dev/images/logo.png' alt='{{brandName}}' width='36' height='36' style='display:block; border:0; outline:none; text-decoration:none;' />
-                          </td>
-                          <td valign='middle' style='font:600 18px Arial, Helvetica, sans-serif; color:#EA580C;'>{{brandName}}</td>
-                        </tr>
-                      </table>
-                    </td>
-                    <td class='stack text-center-sm' valign='middle' align='right' style='padding:8px 0;'>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <td align='center' style='padding:16px 16px 0 16px;'>
-                <table role='presentation' width='100%' cellspacing='0' cellpadding='0' border='0' class='card' style='background:#ffffff; border-radius:10px;'>
-                  <tr>
-                    <td align='center' style='background:#F97316; border-radius:10px 10px 0 0; padding:28px 20px;'>
-                      <div style='font:700 24px Arial, Helvetica, sans-serif; color:#ffffff;'>{{title}}</div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class='p-sm' style='padding:28px; font:16px/1.6 Arial, Helvetica, sans-serif; color:#111827;'>
-                      <div style='font:700 18px Arial, Helvetica, sans-serif; color:#111827; margin-bottom:8px;'>Hi {{name}},</div>
-                      <p style='margin:0 0 16px 0;'>{{message}}</p>
-                      <div style='text-align:center; padding:8px 0 2px;'>
-                        <!--[if mso]>
-                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ctaUrl}}" style="height:48px;v-text-anchor:middle;width:260px;" arcsize="10%" strokecolor="#EA580C" fillcolor="#F97316">
-                            <w:anchorlock/>
-                            <center style="color:#ffffff;font-family:Arial, Helvetica, sans-serif;font-size:16px;font-weight:bold;">{{ctaLabel}}</center>
-                          </v:roundrect>
-                        <![endif]-->
-                        <!--[if !mso]><!-- -->
-                        <a href='{{ctaUrl}}' style='background:#F97316; border:1px solid #EA580C; border-radius:6px; color:#ffffff; display:inline-block; font:700 16px Arial, Helvetica, sans-serif; line-height:48px; text-align:center; text-decoration:none; width:260px;'>{{ctaLabel}}</a>
-                        <!--<![endif]-->
-                      </div>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <td align='center' style='padding:16px;'>
-                <table role='presentation' width='100%' cellspacing='0' cellpadding='0' border='0'>
-                  <tr>
-                    <td align='center' style='font:12px/1.6 Arial, Helvetica, sans-serif; color:#6b7280;'>
-                      <div>© 2025 {{brandName}}. All rights reserved.</div>
-                      <div class='muted' style='margin-top:4px;'>Manage notifications in <a href='https://app.textbee.dev/dashboard/account/' style='color:#6b7280; text-decoration:underline;'>Account settings</a>.</div>
-                      <div class='muted' style='margin-top:4px;'>Questions? Ask the <a href='https://textbee.dev/discord' style='color:#6b7280; text-decoration:underline;'>community on Discord</a>.</div>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>
+{{#> email-layout}}
+  <p style='margin:0 0 14px 0;'>Hi {{name}},</p>
 
+  <p style='margin:0 0 4px 0;'>{{message}}</p>
+
+  {{#if usage}}{{> email-usage}}{{/if}}
+
+  {{#if resetNote}}
+    <p style='margin:14px 0 0 0; font:14px/1.6 Arial, Helvetica, sans-serif; color:#4b5563;'>{{resetNote}}</p>
+  {{/if}}
+
+  {{#if benefits}}
+    <p style='margin:22px 0 8px 0; font:700 15px Arial, Helvetica, sans-serif; color:#111827;'>{{#if benefitsTitle}}{{benefitsTitle}}{{else}}Moving up a plan gets you{{/if}}</p>
+    <table role='presentation' cellpadding='0' cellspacing='0' border='0'>
+      {{#each benefits}}
+        <tr>
+          <td valign='top' style='padding:0 8px 6px 0; font:16px/1.6 Arial, Helvetica, sans-serif; color:#EA580C;'>&bull;</td>
+          <td style='padding:0 0 6px 0; font:15px/1.6 Arial, Helvetica, sans-serif; color:#374151;'>{{this}}</td>
+        </tr>
+      {{/each}}
+    </table>
+  {{/if}}
+
+  {{#if ctaUrl}}{{> email-button}}{{/if}}
+
+  {{#if footnote}}
+    <p style='margin:16px 0 0 0; font:13px/1.6 Arial, Helvetica, sans-serif; color:#6b7280;'>{{footnote}}</p>
+  {{/if}}
+{{/email-layout}}

--- a/api/src/mail/templates/customer-support-confirmation.hbs
+++ b/api/src/mail/templates/customer-support-confirmation.hbs
@@ -1,37 +1,21 @@
-<html lang='en'>
-  <head>
-    <meta charset='UTF-8' />
-    <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-    <title>Support Request Confirmation</title>
-    <style>
-      body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }
-      h1 { color: #2563eb; }
-      .details { background: #ffffff; border-left: 4px solid #2563eb; padding: 15px; margin: 15px 0; }
-      .footer { text-align: center; font-size: 14px; color: #6b7280; margin-top: 30px; padding-top: 20px; border-top: 1px solid #e5e7eb; }
-    </style>
-  </head>
-  <body>
-    <h1>Support Request Submitted</h1>
+{{#> email-layout title='We got your message' preheader='Our team will reply to this address.'}}
+  <p style='margin:0 0 14px 0;'>Hi {{name}},</p>
 
-    <p>Hello {{name}},</p>
+  <p style='margin:0 0 4px 0;'>
+    Thanks for getting in touch. We have your request and will reply to this
+    address. You can add anything else by replying here.
+  </p>
 
-    <p>Thank you for contacting our support team. We have received your message and will get back to you as soon as possible.</p>
+  {{#> email-note}}
+    <div style='font:13px/1.4 Arial, Helvetica, sans-serif; color:#6b7280;'>Category</div>
+    <div style='margin:2px 0 12px 0; color:#111827;'>{{category}}</div>
+    <div style='font:13px/1.4 Arial, Helvetica, sans-serif; color:#6b7280;'>Your message</div>
+    <div style='margin-top:2px; white-space:pre-wrap; color:#111827;'>{{message}}</div>
+  {{/email-note}}
 
-    <div class='details'>
-      <p><strong>Category:</strong> {{category}}</p>
-      <p><strong>Your Message:</strong></p>
-      <p>{{message}}</p>
-    </div>
+  <p style='margin:20px 0 0 0; font:14px/1.6 Arial, Helvetica, sans-serif; color:#4b5563;'>
+    While you wait, the community on Discord may already have an answer.
+  </p>
 
-    <p><strong>Your Contact Information:</strong></p>
-    <p>Name: {{name}}<br />Email: {{email}}<br />Phone: {{#if phone}}{{phone}}{{else}}Not provided{{/if}}</p>
-
-    <p>We will review your request and respond to the email address you provided. If you have any additional information to share, please reply to this email.</p>
-
-    <p>While you wait, the community on Discord may already have an answer. <a href='https://textbee.dev/discord' style='color: #2563eb;'>Join the textbee Discord</a>.</p>
-
-    <div class='footer'>
-      <p>&copy; {{currentYear}} textbee.dev.</p>
-    </div>
-  </body>
-</html>
+  {{> email-button ctaUrl='https://textbee.dev/discord' ctaLabel='Ask the community'}}
+{{/email-layout}}

--- a/api/src/mail/templates/partials/email-button.hbs
+++ b/api/src/mail/templates/partials/email-button.hbs
@@ -1,0 +1,20 @@
+{{!--
+  Primary CTA. The VML half is what makes it clickable and filled in Outlook,
+  which ignores padding and background on an anchor.
+  Context: ctaUrl, ctaLabel.
+--}}
+<table role='presentation' cellpadding='0' cellspacing='0' border='0' style='margin:20px 0 8px 0;'>
+  <tr>
+    <td>
+      <!--[if mso]>
+        <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ctaUrl}}" style="height:46px;v-text-anchor:middle;width:240px;" arcsize="14%" strokecolor="#EA580C" fillcolor="#EA580C">
+          <w:anchorlock/>
+          <center style="color:#ffffff;font-family:Arial, Helvetica, sans-serif;font-size:16px;font-weight:bold;">{{ctaLabel}}</center>
+        </v:roundrect>
+      <![endif]-->
+      <!--[if !mso]><!-- -->
+      <a href='{{ctaUrl}}' style='background:#EA580C; border:1px solid #EA580C; border-radius:6px; color:#ffffff; display:inline-block; font:700 16px Arial, Helvetica, sans-serif; line-height:46px; min-width:240px; text-align:center; text-decoration:none;'>{{ctaLabel}}</a>
+      <!--<![endif]-->
+    </td>
+  </tr>
+</table>

--- a/api/src/mail/templates/partials/email-fallback-link.hbs
+++ b/api/src/mail/templates/partials/email-fallback-link.hbs
@@ -1,0 +1,7 @@
+{{!-- Some clients strip buttons, and some users paste. Context: url. --}}
+<p style='margin:16px 0 0 0; font:13px/1.6 Arial, Helvetica, sans-serif; color:#6b7280;'>
+  If the button does not work, copy this link into your browser:
+</p>
+<p style='margin:4px 0 0 0; font:13px/1.6 Arial, Helvetica, sans-serif; word-break:break-all;'>
+  <a href='{{url}}' style='color:#EA580C;'>{{url}}</a>
+</p>

--- a/api/src/mail/templates/partials/email-layout.hbs
+++ b/api/src/mail/templates/partials/email-layout.hbs
@@ -1,0 +1,83 @@
+{{!--
+  Shared shell for every textbee email.
+
+  Used as a partial block, so a template is only its content:
+    {{#> email-layout title="..." preheader="..."}} ...content... {{/email-layout}}
+
+  Two constraints shape this markup:
+  - The mailer runs inline-css over the output, which strips @media rules.
+    Nothing here may depend on a media query. Widths are fluid, capped with
+    max-width, so it adapts without one.
+  - Outlook renders through Word, which ignores max-width on body, box-shadow,
+    and most modern CSS. Layout is tables, and the CTA has a VML fallback.
+--}}
+<!doctype html>
+<html lang='en' xmlns:v='urn:schemas-microsoft-com:vml' xmlns:o='urn:schemas-microsoft-com:office:office'>
+  <head>
+    <meta charset='utf-8' />
+    <meta name='viewport' content='width=device-width, initial-scale=1' />
+    <meta http-equiv='x-ua-compatible' content='ie=edge' />
+    <meta name='color-scheme' content='light' />
+    <meta name='supported-color-schemes' content='light' />
+    <title>{{title}} - {{brandName}}</title>
+    <!--[if mso]>
+      <style type="text/css"> body, table, td, a { font-family: Helvetica, Arial, sans-serif !important; } </style>
+    <![endif]-->
+  </head>
+  <body style='margin:0; padding:0; background:#f7f9fc; -webkit-font-smoothing:antialiased;'>
+    {{!-- The inbox preview line. Hidden in the body, so it must be set per email. --}}
+    <div style='display:none; visibility:hidden; opacity:0; color:transparent; height:0; width:0; overflow:hidden; mso-hide:all;'>
+      {{preheader}}
+    </div>
+
+    <table role='presentation' cellpadding='0' cellspacing='0' border='0' width='100%' style='background:#f7f9fc;'>
+      <tr>
+        <td align='center' style='padding:24px 12px;'>
+          <table role='presentation' cellpadding='0' cellspacing='0' border='0' width='600' style='width:100%; max-width:600px;'>
+
+            <tr>
+              <td style='padding:4px 4px 16px 4px;'>
+                <table role='presentation' cellspacing='0' cellpadding='0' border='0'>
+                  <tr>
+                    <td valign='middle' style='padding-right:10px;'>
+                      <img src='https://textbee.dev/images/logo.png' alt='{{brandName}}' width='32' height='32' style='display:block; border:0; outline:none; text-decoration:none;' />
+                    </td>
+                    <td valign='middle' style='font:600 18px Arial, Helvetica, sans-serif; color:#EA580C;'>{{brandName}}</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <table role='presentation' width='100%' cellspacing='0' cellpadding='0' border='0' style='background:#ffffff; border:1px solid #e9edf3; border-radius:10px;'>
+                  <tr>
+                    <td style='padding:28px 28px 8px 28px; font:16px/1.6 Arial, Helvetica, sans-serif; color:#111827;'>
+                      <h1 style='margin:0 0 16px 0; font:700 22px/1.35 Arial, Helvetica, sans-serif; color:#111827;'>{{title}}</h1>
+                      {{> @partial-block}}
+                    </td>
+                  </tr>
+                  <tr><td style='height:24px; line-height:24px; font-size:0;'>&nbsp;</td></tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td align='center' style='padding:20px 8px 4px 8px; font:12px/1.7 Arial, Helvetica, sans-serif; color:#6b7280;'>
+                <div>
+                  <a href='https://app.textbee.dev/dashboard' style='color:#6b7280; text-decoration:underline;'>Dashboard</a>
+                  &nbsp;·&nbsp;
+                  <a href='https://textbee.dev/docs' style='color:#6b7280; text-decoration:underline;'>Docs</a>
+                  &nbsp;·&nbsp;
+                  <a href='https://textbee.dev/discord' style='color:#6b7280; text-decoration:underline;'>Discord</a>
+                </div>
+                <div style='margin-top:6px;'>&copy; {{year}} {{brandName}}</div>
+              </td>
+            </tr>
+
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/api/src/mail/templates/partials/email-note.hbs
+++ b/api/src/mail/templates/partials/email-note.hbs
@@ -1,0 +1,8 @@
+{{!-- Quiet aside for reassurance or a caveat. Context: @partial-block. --}}
+<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='margin:20px 0 0 0; background:#f7f9fc; border:1px solid #e9edf3; border-radius:8px;'>
+  <tr>
+    <td style='padding:14px 16px; font:14px/1.6 Arial, Helvetica, sans-serif; color:#4b5563;'>
+      {{> @partial-block}}
+    </td>
+  </tr>
+</table>

--- a/api/src/mail/templates/partials/email-usage.hbs
+++ b/api/src/mail/templates/partials/email-usage.hbs
@@ -1,0 +1,22 @@
+{{!--
+  The usage figure, pulled out of the prose. This is the number that makes the
+  email worth opening, so it gets its own block and a bar rather than sitting
+  mid-sentence. Table-based so Outlook renders the bar.
+  Context: usage.label, usage.used, usage.limit, usage.percent.
+--}}
+<table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='margin:20px 0 4px 0; background:#f7f9fc; border:1px solid #e9edf3; border-radius:8px;'>
+  <tr>
+    <td style='padding:16px;'>
+      <div style='font:13px/1.4 Arial, Helvetica, sans-serif; color:#6b7280;'>{{usage.label}}</div>
+      <div style='margin-top:4px; font:700 22px/1.3 Arial, Helvetica, sans-serif; color:#111827;'>
+        {{usage.used}} <span style='font-weight:400; color:#6b7280;'>of {{usage.limit}}</span>
+      </div>
+      <table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='margin-top:12px; background:#e9edf3; border-radius:999px;'>
+        <tr>
+          <td width='{{usage.percent}}%' style='height:8px; line-height:8px; font-size:0; background:#EA580C; border-radius:999px;'>&nbsp;</td>
+          <td style='height:8px; line-height:8px; font-size:0;'>&nbsp;</td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/api/src/mail/templates/password-reset-request.hbs
+++ b/api/src/mail/templates/password-reset-request.hbs
@@ -1,118 +1,22 @@
-<html>
-  <head>
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-        line-height: 1.6;
-        color: #333333;
-        max-width: 600px;
-        margin: 0 auto;
-        padding: 20px;
-      }
-      .container {
-        background-color: #ffffff;
-        border-radius: 8px;
-        padding: 30px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      }
-      .header {
-        text-align: center;
-        margin-bottom: 30px;
-      }
-      .reset-button {
-        display: inline-block;
-        background-color: #007bff;
-        color: white;
-        padding: 12px 24px;
-        text-decoration: none;
-        border-radius: 4px;
-        margin: 20px 0;
-      }
-      .reset-button:hover {
-        background-color: #0056b3;
-      }
-      .divider {
-        border-top: 1px solid #e0e0e0;
-        margin: 20px 0;
-      }
-      .otp-section {
-        background-color: #f8f9fa;
-        padding: 15px;
-        border-radius: 4px;
-        text-align: center;
-        margin: 20px 0;
-      }
-      .community-section {
-        text-align: center;
-      }
-    </style>
-  </head>
-  <body>
-    <div class='container'>
-      <div class='header'>
-        <h1>Password Reset Request</h1>
-      </div>
+{{#> email-layout title='Reset your password' preheader='Use the button or the code below to set a new password.'}}
+  <p style='margin:0 0 14px 0;'>Hi {{name}},</p>
 
-      <p>Hello {{name}},</p>
+  <p style='margin:0 0 4px 0;'>
+    We received a request to reset the password on your textbee account. Choose a new one here.
+  </p>
 
-      <p>We have received a request to reset your password. If you did not make
-        this request, please ignore this email. Otherwise, you can reset your
-        password using the button below.</p>
+  {{> email-button ctaUrl=resetLink ctaLabel='Set a new password'}}
 
-      <div style='text-align: center;'>
-        <a href='{{resetLink}}' class='reset-button'>Reset Password</a>
-      </div>
+  {{#if otp}}
+    {{#> email-note}}
+      <div style='font:13px/1.4 Arial, Helvetica, sans-serif; color:#6b7280;'>Or enter this code</div>
+      <div style='margin-top:6px; font:700 26px/1.2 Courier New, Courier, monospace; letter-spacing:4px; color:#111827;'>{{otp}}</div>
+    {{/email-note}}
+  {{/if}}
 
-      <div class='divider'></div>
+  {{> email-fallback-link url=resetLink}}
 
-      <p>If the button above doesn't work, you can copy and paste the following
-        link into your browser:</p>
-      <p style='word-break: break-all;'>{{resetLink}}</p>
-
-      <div class='otp-section'>
-        <p>Alternatively, you can use this OTP:</p>
-        <div class='otp-code'>{{otp}}</div>
-      </div>
-
-      <div class='divider'></div>
-
-      <div class='footer'>
-        <p>
-          Thank you,<br />
-          <strong>textbee.dev</strong>
-        </p>
-        <p style='font-size: 12px; color: #999;'>
-          If you didn't request this password reset, you can safely ignore this
-          email.
-        </p>
-
-        <div class='divider'></div>
-        <div class='community-section'>
-          <p style='font-size: 14px; margin-bottom: 15px;'>Join our community!</p>
-          <a
-            href='https://textbee.dev/discord'
-            style='display: inline-block; margin: 0 10px; color: #7289DA; text-decoration: none;'
-          >
-            <img
-              src='https://cdn.prod.website-files.com/6257adef93867e50d84d30e2/636e0a6918e57475a843f59f_icon_clyde_black_RGB.svg'
-              alt='Discord'
-              style='width: 20px; vertical-align: middle;'
-            />
-            Join Discord
-          </a>
-          <a
-            href='https://github.com/textbee/textbee'
-            style='display: inline-block; margin: 0 10px; color: #333; text-decoration: none;'
-          >
-            <img
-              src='https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'
-              alt='GitHub'
-              style='width: 20px; vertical-align: middle;'
-            />
-            Star on GitHub
-          </a>
-        </div>
-      </div>
-    </div>
-  </body>
-</html>
+  <p style='margin:20px 0 0 0; font:13px/1.6 Arial, Helvetica, sans-serif; color:#6b7280;'>
+    If you did not ask for this, you can ignore this email. Your password stays as it is.
+  </p>
+{{/email-layout}}

--- a/api/src/mail/templates/password-reset-success.hbs
+++ b/api/src/mail/templates/password-reset-success.hbs
@@ -1,81 +1,14 @@
-<html>
-  <head>
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-        line-height: 1.6;
-        color: #333333;
-        max-width: 600px;
-        margin: 0 auto;
-        padding: 20px;
-      }
-      .container {
-        background-color: #ffffff;
-        border-radius: 8px;
-        padding: 30px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      }
-      .header {
-        text-align: center;
-        margin-bottom: 30px;
-      }
-      .divider {
-        border-top: 1px solid #e0e0e0;
-        margin: 20px 0;
-      }
-      .community-section {
-        text-align: center;
-      }
-    </style>
-  </head>
-  <body>
-    <div class='container'>
-      <div class='header'>
-        <h1>Password Reset Successful</h1>
-      </div>
+{{#> email-layout title='Your password was changed' preheader='If this was not you, contact support right away.'}}
+  <p style='margin:0 0 14px 0;'>Hi {{name}},</p>
 
-      <p>Hello {{name}},</p>
+  <p style='margin:0 0 4px 0;'>
+    Your textbee password has been changed. You can sign in with it now.
+  </p>
 
-      <p>Your password has been successfully reset. You can now login to your account using your new password.</p>
+  {{> email-button ctaUrl='https://app.textbee.dev/dashboard' ctaLabel='Go to dashboard'}}
 
-      <div class='divider'></div>
-
-      <div class='footer'>
-        <p>
-          Thank you,<br />
-          <strong>textbee.dev</strong>
-        </p>
-        <p style='font-size: 12px; color: #999;'>
-          If you didn't reset your password, please contact our support team immediately.
-        </p>
-
-        <div class='divider'></div>
-        <div class='community-section'>
-          <p style='font-size: 14px; margin-bottom: 15px;'>Join our community!</p>
-          <a
-            href='https://textbee.dev/discord'
-            style='display: inline-block; margin: 0 10px; color: #7289DA; text-decoration: none;'
-          >
-            <img
-              src='https://cdn.prod.website-files.com/6257adef93867e50d84d30e2/636e0a6918e57475a843f59f_icon_clyde_black_RGB.svg'
-              alt='Discord'
-              style='width: 20px; vertical-align: middle;'
-            />
-            Join Discord
-          </a>
-          <a
-            href='https://github.com/textbee/textbee'
-            style='display: inline-block; margin: 0 10px; color: #333; text-decoration: none;'
-          >
-            <img
-              src='https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'
-              alt='GitHub'
-              style='width: 20px; vertical-align: middle;'
-            />
-            Star on GitHub
-          </a>
-        </div>
-      </div>
-    </div>
-  </body>
-</html>
+  {{#> email-note}}
+    <strong style='color:#111827;'>Not you?</strong>
+    Reply to this email straight away and we will secure the account.
+  {{/email-note}}
+{{/email-layout}}

--- a/api/src/mail/templates/verify-email.hbs
+++ b/api/src/mail/templates/verify-email.hbs
@@ -1,104 +1,15 @@
-<html></html>
-  <head>
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-        line-height: 1.6;
-        color: #333333;
-        max-width: 600px;
-        margin: 0 auto;
-        padding: 20px;
-      }
-      .container {
-        background-color: #ffffff;
-        border-radius: 8px;
-        padding: 30px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      }
-      .header {
-        text-align: center;
-        margin-bottom: 30px;
-      }
-      .reset-button {
-        display: inline-block;
-        background-color: #007bff;
-        color: white;
-        padding: 12px 24px;
-        text-decoration: none;
-        border-radius: 4px;
-        margin: 20px 0;
-      }
-      .reset-button:hover {
-        background-color: #0056b3;
-      }
-      .divider {
-        border-top: 1px solid #e0e0e0;
-        margin: 20px 0;
-      }
-      .community-section {
-        text-align: center;
-      }
-    </style>
-  </head>
-  <body>
-    <div class='container'>
-      <div class='header'>
-        <h1>Verify Your Email Address</h1>
-      </div>
+{{#> email-layout title='Verify your email address' preheader='One click to finish setting up your textbee account.'}}
+  <p style='margin:0 0 14px 0;'>Hi {{name}},</p>
 
-      <p>Hello {{name}},</p>
+  <p style='margin:0 0 4px 0;'>
+    Welcome to textbee. Confirm this address and your account is ready to send.
+  </p>
 
-      <p>Welcome to textbee! To complete your registration and verify your email address, please click the button below.</p>
+  {{> email-button ctaUrl=verificationLink ctaLabel='Verify my email'}}
 
-      <div style='text-align: center;'>
-        <a href='{{verificationLink}}' class='reset-button'>Verify Email</a>
-      </div>
+  {{> email-fallback-link url=verificationLink}}
 
-      <div class='divider'></div>
-
-      <p>If the button above doesn't work, you can copy and paste the following link into your browser:</p>
-      <p style='word-break: break-all;'>{{verificationLink}}</p>
-
-
-
-      <div class='divider'></div>
-
-      <div class='footer'>
-        <p>
-          Thank you,<br />
-          <strong>textbee.dev</strong>
-        </p>
-        <p style='font-size: 12px; color: #999;'>
-          If you didn't create an account with textbee, you can safely ignore this email.
-        </p>
-
-        <div class='divider'></div>
-        <div class='community-section'>
-          <p style='font-size: 14px; margin-bottom: 15px;'>Join our community!</p>
-          <a
-            href='https://textbee.dev/discord'
-            style='display: inline-block; margin: 0 10px; color: #7289DA; text-decoration: none;'
-          >
-            <img
-              src='https://cdn.prod.website-files.com/6257adef93867e50d84d30e2/636e0a6918e57475a843f59f_icon_clyde_black_RGB.svg'
-              alt='Discord'
-              style='width: 20px; vertical-align: middle;'
-            />
-            Join Discord
-          </a>
-          <a
-            href='https://github.com/textbee/textbee'
-            style='display: inline-block; margin: 0 10px; color: #333; text-decoration: none;'
-          >
-            <img
-              src='https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'
-              alt='GitHub'
-              style='width: 20px; vertical-align: middle;'
-            />
-            Star on GitHub
-          </a>
-        </div>
-      </div>
-    </div>
-  </body>
-</html>
+  <p style='margin:20px 0 0 0; font:13px/1.6 Arial, Helvetica, sans-serif; color:#6b7280;'>
+    If you did not create a textbee account, you can ignore this email and nothing will happen.
+  </p>
+{{/email-layout}}

--- a/api/src/mail/templates/webhook-auto-disable-admin-summary.hbs
+++ b/api/src/mail/templates/webhook-auto-disable-admin-summary.hbs
@@ -1,58 +1,24 @@
-<html>
-  <head>
-    <meta charset='utf-8' />
-    <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-    <title>{{title}} – {{runAt}}</title>
-    <style>
-      body { font-family: Arial, sans-serif; line-height: 1.5; color: #333; margin: 0; padding: 0; }
-      .container { max-width: 900px; margin: 0 auto; padding: 20px; }
-      .header { padding: 16px 0; border-bottom: 1px solid #eee; }
-      .title { font-size: 18px; font-weight: bold; }
-      .meta { font-size: 12px; color: #666; margin-top: 4px; }
-      table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 13px; }
-      th, td { padding: 10px; text-align: left; border-bottom: 1px solid #ddd; }
-      th { background-color: #f5f5f5; font-weight: 600; }
-      .url { word-break: break-all; max-width: 240px; }
-      .footer { font-size: 12px; color: #777; margin-top: 24px; padding-top: 16px; border-top: 1px solid #eee; }
-    </style>
-  </head>
-  <body>
-    <div class='container'>
-      <div class='header'>
-        <div class='title'>{{title}}</div>
-        <div class='meta'>Run at {{runAt}} · {{count}} subscription(s) auto-disabled</div>
-      </div>
-      <table>
-        <thead>
-          <tr>
-            <th>Subscription ID</th>
-            <th>Delivery URL</th>
-            <th>Failed</th>
-            <th>Success</th>
-            <th>Total</th>
-            <th>Failure rate %</th>
-            <th>Period (days)</th>
-            <th>User name</th>
-            <th>User email</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each disabledList}}
-          <tr>
-            <td>{{this.subscriptionId}}</td>
-            <td class='url'>{{this.deliveryUrl}}</td>
-            <td>{{this.failureCount}}</td>
-            <td>{{this.successCount}}</td>
-            <td>{{this.totalAttempts}}</td>
-            <td>{{this.failureRatePercent}}</td>
-            <td>{{this.lookbackDays}}</td>
-            <td>{{this.userName}}</td>
-            <td>{{this.userEmail}}</td>
-          </tr>
-          {{/each}}
-        </tbody>
-      </table>
-      <div class='footer'>{{brandName}} – Webhook auto-disable cron</div>
-    </div>
-  </body>
-</html>
+{{#> email-layout title='Webhooks auto-disabled'}}
+  <p style='margin:0 0 4px 0;'>
+    Run at {{runAt}}. Subscriptions turned off: {{count}}.
+  </p>
+
+  <table role='presentation' width='100%' cellpadding='0' cellspacing='0' border='0' style='margin-top:20px; border:1px solid #e9edf3; border-radius:8px; border-collapse:separate;'>
+    <tr style='background:#f7f9fc;'>
+      <th align='left' style='padding:10px 12px; font:600 12px Arial, Helvetica, sans-serif; color:#6b7280;'>Subscription</th>
+      <th align='left' style='padding:10px 12px; font:600 12px Arial, Helvetica, sans-serif; color:#6b7280;'>Endpoint</th>
+      <th align='right' style='padding:10px 12px; font:600 12px Arial, Helvetica, sans-serif; color:#6b7280;'>Failed</th>
+      <th align='right' style='padding:10px 12px; font:600 12px Arial, Helvetica, sans-serif; color:#6b7280;'>Total</th>
+      <th align='right' style='padding:10px 12px; font:600 12px Arial, Helvetica, sans-serif; color:#6b7280;'>Rate</th>
+    </tr>
+    {{#each rows}}
+      <tr>
+        <td style='padding:10px 12px; font:12px/1.5 Courier New, Courier, monospace; color:#374151; border-top:1px solid #e9edf3;'>{{this.id}}</td>
+        <td style='padding:10px 12px; font:12px/1.5 Arial, Helvetica, sans-serif; color:#374151; word-break:break-all; border-top:1px solid #e9edf3;'>{{this.deliveryUrl}}</td>
+        <td align='right' style='padding:10px 12px; font:12px/1.5 Arial, Helvetica, sans-serif; color:#374151; border-top:1px solid #e9edf3;'>{{this.failed}}</td>
+        <td align='right' style='padding:10px 12px; font:12px/1.5 Arial, Helvetica, sans-serif; color:#374151; border-top:1px solid #e9edf3;'>{{this.total}}</td>
+        <td align='right' style='padding:10px 12px; font:12px/1.5 Arial, Helvetica, sans-serif; color:#374151; border-top:1px solid #e9edf3;'>{{this.failureRate}}%</td>
+      </tr>
+    {{/each}}
+  </table>
+{{/email-layout}}

--- a/api/src/mail/templates/webhook-subscription-disabled.hbs
+++ b/api/src/mail/templates/webhook-subscription-disabled.hbs
@@ -1,88 +1,29 @@
-<html lang='en' xmlns:v='urn:schemas-microsoft-com:vml' xmlns:o='urn:schemas-microsoft-com:office:office'>
-  <head>
-    <meta charset='utf-8' />
-    <meta name='viewport' content='width=device-width, initial-scale=1' />
-    <meta http-equiv='x-ua-compatible' content='ie=edge' />
-    <title>{{title}} • {{brandName}}</title>
-    <style>
-      .preheader { display:none !important; visibility:hidden; opacity:0; color:transparent; height:0; width:0; overflow:hidden; mso-hide:all; }
-      @media screen and (max-width: 600px) { .container { width:100% !important; } .stack { display:block !important; width:100% !important; } .p-sm { padding:16px !important; } .text-center-sm { text-align:center !important; } .hide-sm { display:none !important; } }
-    </style>
-    <!--[if mso]>
-      <style type="text/css"> body, table, td, a { font-family: Helvetica, Arial, sans-serif !important; } </style>
-    <![endif]-->
-  </head>
-  <body style='margin:0; padding:0; background:#f7f9fc;'>
-    <div class='preheader'>Your webhook was paused due to delivery failures. Re-enable it when ready.</div>
-    <table role='presentation' cellpadding='0' cellspacing='0' border='0' width='100%' class='email-bg' style='background:#f7f9fc;'>
-      <tr>
-        <td align='center' style='padding:24px;'>
-          <table role='presentation' cellpadding='0' cellspacing='0' border='0' width='600' class='container' style='width:600px; max-width:600px;'>
-            <tr>
-              <td style='padding:12px 16px 0 16px;'>
-                <table role='presentation' width='100%' cellspacing='0' cellpadding='0' border='0'>
-                  <tr>
-                    <td class='stack' valign='middle' style='padding:8px 0;'>
-                      <table role='presentation' cellspacing='0' cellpadding='0' border='0'>
-                        <tr>
-                          <td valign='middle' style='padding-right:10px;'>
-                            <img src='https://textbee.dev/images/logo.png' alt='{{brandName}}' width='36' height='36' style='display:block; border:0; outline:none; text-decoration:none;' />
-                          </td>
-                          <td valign='middle' style='font:600 18px Arial, Helvetica, sans-serif; color:#EA580C;'>{{brandName}}</td>
-                        </tr>
-                      </table>
-                    </td>
-                    <td class='stack text-center-sm' valign='middle' align='right' style='padding:8px 0;'>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <td align='center' style='padding:16px 16px 0 16px;'>
-                <table role='presentation' width='100%' cellspacing='0' cellpadding='0' border='0' class='card' style='background:#ffffff; border-radius:10px;'>
-                  <tr>
-                    <td align='center' style='background:#F97316; border-radius:10px 10px 0 0; padding:28px 20px;'>
-                      <div style='font:700 24px Arial, Helvetica, sans-serif; color:#ffffff;'>{{title}}</div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class='p-sm' style='padding:28px; font:16px/1.6 Arial, Helvetica, sans-serif; color:#111827;'>
-                      <div style='font:700 18px Arial, Helvetica, sans-serif; color:#111827; margin-bottom:8px;'>Hi {{name}},</div>
-                      <p style='margin:0 0 8px 0;'>We've temporarily disabled this webhook so repeated failures don't affect your account.</p>
-                      <p style='margin:0 0 8px 0;'>In the last {{lookbackDays}} days: {{failureCount}} failed, {{successCount}} succeeded ({{totalAttempts}} total) — {{failureRatePercent}}% failure rate.</p>
-                      <p style='margin:0 0 16px 0;'>Fix your endpoint, then re-enable the webhook in the dashboard when you're ready.</p>
-                      <div style='text-align:center; padding:8px 0 2px;'>
-                        <!--[if mso]>
-                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ctaUrl}}" style="height:48px;v-text-anchor:middle;width:260px;" arcsize="10%" strokecolor="#EA580C" fillcolor="#F97316">
-                            <w:anchorlock/>
-                            <center style="color:#ffffff;font-family:Arial, Helvetica, sans-serif;font-size:16px;font-weight:bold;">{{ctaLabel}}</center>
-                          </v:roundrect>
-                        <![endif]-->
-                        <!--[if !mso]><!-- -->
-                        <a href='{{ctaUrl}}' style='background:#F97316; border:1px solid #EA580C; border-radius:6px; color:#ffffff; display:inline-block; font:700 16px Arial, Helvetica, sans-serif; line-height:48px; text-align:center; text-decoration:none; width:260px;'>{{ctaLabel}}</a>
-                        <!--<![endif]-->
-                      </div>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <td align='center' style='padding:16px;'>
-                <table role='presentation' width='100%' cellspacing='0' cellpadding='0' border='0'>
-                  <tr>
-                    <td align='center' style='font:12px/1.6 Arial, Helvetica, sans-serif; color:#6b7280;'>
-                      <div>© 2025 {{brandName}}. All rights reserved.</div>
-                      <div class='muted' style='margin-top:4px;'>Manage webhooks in <a href='https://app.textbee.dev/dashboard/account/' style='color:#6b7280; text-decoration:underline;'>Account settings</a>.</div>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>
+{{#> email-layout title='We paused one of your webhooks' preheader='Repeated delivery failures, so we turned it off. Re-enable it when the endpoint is fixed.'}}
+  <p style='margin:0 0 14px 0;'>Hi {{name}},</p>
+
+  <p style='margin:0 0 4px 0;'>
+    Deliveries to this endpoint kept failing, so we turned the webhook off. That
+    stops the retries from piling up against your account.
+  </p>
+
+  {{#> email-note}}
+    {{#if subscriptionName}}
+      <div style='font:13px/1.4 Arial, Helvetica, sans-serif; color:#6b7280;'>Webhook</div>
+      <div style='margin:2px 0 12px 0; color:#111827;'>{{subscriptionName}}</div>
+    {{/if}}
+    <div style='font:13px/1.4 Arial, Helvetica, sans-serif; color:#6b7280;'>Endpoint</div>
+    <div style='margin:2px 0 12px 0; word-break:break-all; color:#111827;'>{{deliveryUrl}}</div>
+    {{#if totalAttempts}}
+      <div style='font:13px/1.4 Arial, Helvetica, sans-serif; color:#6b7280;'>Last {{lookbackDays}} days</div>
+      <div style='margin-top:2px; color:#111827;'>
+        {{failureCount}} failed, {{successCount}} succeeded out of {{totalAttempts}} attempts ({{failureRatePercent}}% failure rate)
+      </div>
+    {{/if}}
+  {{/email-note}}
+
+  <p style='margin:20px 0 0 0;'>
+    Fix the endpoint, then switch the webhook back on in the dashboard.
+  </p>
+
+  {{> email-button}}
+{{/email-layout}}

--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "**/*spec.ts",
+    "scripts"
+  ]
 }


### PR DESCRIPTION
Six of the eight templates were on older markup: no table layout, no preheader, and off-brand colors, so they rendered badly in Outlook. `verify-email` also had a stray empty `<html></html>` before its own `<head>`.

- All eight now share one layout plus header, footer, button, and usage partials.
- The mailer inlines CSS before sending, which strips `@media` rules, so the layout is fluid rather than depending on one.
- Billing emails carry the usage figures as their own block instead of a single sentence, with a per-type subject, preheader, and CTA. Copy leads with the reader's situation and offers the free option before the paid one.
- Upgrade CTA now points at `/pricing` rather than a landing page anchor, and the duplicated subject maps are one map.
- Monthly usage is a rolling 30 day window, not a billing period. The copy said otherwise and is now correct.

Adds `pnpm preview:emails`, which renders every template the way the mailer does and fails on structural problems. It caught a quoted font name breaking out of its own style attribute.

398 API tests pass. **Not yet checked in a real Outlook client**, which is the one that matters here.