### PR TITLE
Supply the shared email layout context from MailService

### DIFF
--- a/api/src/billing/billing-notifications.listener.ts
+++ b/api/src/billing/billing-notifications.listener.ts
@@ -55,8 +55,6 @@ export class BillingNotificationsListener {
       context: {
         ...content,
         name: user.name?.split(' ')?.[0] || 'there',
-        brandName: 'textbee.dev',
-        year: new Date().getFullYear(),
       },
       from: undefined,
     })

--- a/api/src/billing/queue/billing-notifications.processor.ts
+++ b/api/src/billing/queue/billing-notifications.processor.ts
@@ -67,8 +67,6 @@ export class BillingNotificationsProcessor {
       context: {
         ...content,
         name: user.name?.split(' ')?.[0] || 'there',
-        brandName: 'textbee.dev',
-        year: new Date().getFullYear(),
       },
       from: undefined,
     })

--- a/api/src/mail/mail.service.spec.ts
+++ b/api/src/mail/mail.service.spec.ts
@@ -1,0 +1,79 @@
+import { MailService } from './mail.service'
+
+const build = () => {
+  const mailerService: any = { sendMail: jest.fn().mockResolvedValue(undefined) }
+  return { service: new MailService(mailerService), mailerService }
+}
+
+describe('MailService', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('adds the shared layout context to every templated email', async () => {
+    const { service, mailerService } = build()
+
+    await service.sendEmailFromTemplate({
+      to: 'user@example.com',
+      subject: 'Password reset',
+      template: 'password-reset-request',
+      context: { name: 'Ada' },
+    })
+
+    const { context } = mailerService.sendMail.mock.calls[0][0]
+    expect(context).toMatchObject({
+      name: 'Ada',
+      brandName: 'textbee.dev',
+      year: new Date().getFullYear(),
+    })
+  })
+
+  it('keeps the shared layout values authoritative', async () => {
+    const { service, mailerService } = build()
+
+    await service.sendEmailFromTemplate({
+      to: 'user@example.com',
+      subject: 'Password reset',
+      template: 'password-reset-request',
+      context: { brandName: 'somewhere-else', year: 1999 },
+    })
+
+    const { context } = mailerService.sendMail.mock.calls[0][0]
+    expect(context.brandName).toBe('textbee.dev')
+    expect(context.year).toBe(new Date().getFullYear())
+  })
+
+  it('works when a caller passes no context at all', async () => {
+    const { service, mailerService } = build()
+
+    await service.sendEmailFromTemplate({
+      to: 'user@example.com',
+      subject: 'Password reset',
+      template: 'password-reset-request',
+    })
+
+    expect(mailerService.sendMail.mock.calls[0][0].context).toMatchObject({
+      brandName: 'textbee.dev',
+    })
+  })
+
+  it('swallows a send failure and logs a redacted recipient', async () => {
+    const { service, mailerService } = build()
+    const logger = jest
+      .spyOn((service as any).logger, 'error')
+      .mockImplementation(() => undefined)
+    mailerService.sendMail.mockRejectedValue(new Error('smtp down'))
+
+    await expect(
+      service.sendEmailFromTemplate({
+        to: 'someone@example.com',
+        subject: 'Password reset',
+        template: 'password-reset-request',
+        context: {},
+      }),
+    ).resolves.toBeUndefined()
+
+    const message = logger.mock.calls[0][0] as string
+    expect(message).toContain('password-reset-request')
+    expect(message).toContain('so***@example.com')
+    expect(message).not.toContain('someone@example.com')
+  })
+})

--- a/api/src/mail/mail.service.ts
+++ b/api/src/mail/mail.service.ts
@@ -7,6 +7,20 @@ const layoutContext = () => ({
   year: new Date().getFullYear(),
 })
 
+/** Keeps recipient addresses out of the logs while staying traceable. */
+const redactRecipient = (to: ISendMailOptions['to']): string => {
+  const first = Array.isArray(to) ? to[0] : to
+  const address = typeof first === 'string' ? first : first?.address
+  if (!address) {
+    return 'unknown recipient'
+  }
+  const [local, domain] = address.split('@')
+  if (!domain) {
+    return 'redacted'
+  }
+  return `${local.slice(0, 2)}***@${domain}`
+}
+
 @Injectable()
 export class MailService {
   private readonly logger = new Logger(MailService.name)
@@ -30,7 +44,9 @@ export class MailService {
     try {
       await this.mailerService.sendMail(sendMailOptions)
     } catch (e) {
-      this.logger.error(`Failed to send email to ${to}`, e?.stack || e)
+      this.logger.error(
+        `Failed to send email to ${redactRecipient(to)}: ${e?.message}`,
+      )
     }
   }
 
@@ -40,7 +56,7 @@ export class MailService {
       cc,
       subject,
       template,
-      context: { ...layoutContext(), ...context },
+      context: { ...context, ...layoutContext() },
     }
 
     if (from) {
@@ -55,8 +71,7 @@ export class MailService {
       await this.mailerService.sendMail(sendMailOptions)
     } catch (e) {
       this.logger.error(
-        `Failed to send "${template}" email to ${to}`,
-        e?.stack || e,
+        `Failed to send "${template}" email to ${redactRecipient(to)}: ${e?.message}`,
       )
     }
   }

--- a/api/src/mail/mail.service.ts
+++ b/api/src/mail/mail.service.ts
@@ -1,8 +1,16 @@
 import { ISendMailOptions, MailerService } from '@nest-modules/mailer'
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
+
+// Context every template gets via the shared email-layout partial.
+const layoutContext = () => ({
+  brandName: 'textbee.dev',
+  year: new Date().getFullYear(),
+})
 
 @Injectable()
 export class MailService {
+  private readonly logger = new Logger(MailService.name)
+
   constructor(private readonly mailerService: MailerService) {}
 
   async sendEmail({ to, subject, html, from }) {
@@ -22,7 +30,7 @@ export class MailService {
     try {
       await this.mailerService.sendMail(sendMailOptions)
     } catch (e) {
-      console.log(e)
+      this.logger.error(`Failed to send email to ${to}`, e?.stack || e)
     }
   }
 
@@ -32,7 +40,7 @@ export class MailService {
       cc,
       subject,
       template,
-      context,
+      context: { ...layoutContext(), ...context },
     }
 
     if (from) {
@@ -46,7 +54,10 @@ export class MailService {
     try {
       await this.mailerService.sendMail(sendMailOptions)
     } catch (e) {
-      console.log(e)
+      this.logger.error(
+        `Failed to send "${template}" email to ${to}`,
+        e?.stack || e,
+      )
     }
   }
 }

--- a/api/src/mail/templates/webhook-auto-disable-admin-summary.hbs
+++ b/api/src/mail/templates/webhook-auto-disable-admin-summary.hbs
@@ -1,4 +1,4 @@
-{{#> email-layout title='Webhooks auto-disabled'}}
+{{#> email-layout title='Webhooks auto-disabled' preheader='Subscriptions turned off after repeated delivery failures.'}}
   <p style='margin:0 0 4px 0;'>
     Run at {{runAt}}. Subscriptions turned off: {{count}}.
   </p>

--- a/api/src/webhook/webhook.service.spec.ts
+++ b/api/src/webhook/webhook.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpException } from '@nestjs/common'
 import * as crypto from 'crypto'
 import axios from 'axios'
-import { WebhookService } from './webhook.service'
+import { WebhookService, redactDeliveryUrl } from './webhook.service'
 
 jest.mock('axios')
 const mockedAxios = axios as jest.Mocked<typeof axios>
@@ -26,6 +26,28 @@ const build = () => {
 
   return { service, webhookSubscriptionModel, webhookNotificationModel }
 }
+
+describe('redactDeliveryUrl', () => {
+  it('drops userinfo and the query string', () => {
+    expect(redactDeliveryUrl('https://user:pass@example.com/hook?token=secret')).toBe(
+      'https://example.com/hook?[redacted]',
+    )
+  })
+
+  it('keeps origin and path when there is nothing sensitive', () => {
+    expect(redactDeliveryUrl('https://example.com/hook')).toBe(
+      'https://example.com/hook',
+    )
+  })
+
+  it('returns a placeholder for an unparseable url', () => {
+    expect(redactDeliveryUrl('not-a-url')).toBe('[unparseable url]')
+  })
+
+  it('returns an empty string for an empty url', () => {
+    expect(redactDeliveryUrl('')).toBe('')
+  })
+})
 
 describe('WebhookService', () => {
   beforeEach(() => jest.clearAllMocks())

--- a/api/src/webhook/webhook.service.ts
+++ b/api/src/webhook/webhook.service.ts
@@ -20,6 +20,23 @@ import { WebhookQueueService } from './queue/webhook-queue.service'
 import { MailService } from '../mail/mail.service'
 import { UsersService } from '../users/users.service'
 
+/**
+ * Endpoints can carry a token in the query or in userinfo, so the admin summary
+ * only ever shows origin and path.
+ */
+export const redactDeliveryUrl = (deliveryUrl: string): string => {
+  if (!deliveryUrl) {
+    return ''
+  }
+  try {
+    const url = new URL(deliveryUrl)
+    const query = url.search ? '?[redacted]' : ''
+    return `${url.protocol}//${url.host}${url.pathname}${query}`
+  } catch {
+    return '[unparseable url]'
+  }
+}
+
 @Injectable()
 export class WebhookService {
   constructor(
@@ -1037,7 +1054,7 @@ export class WebhookService {
             count: disabledInThisRun.length,
             rows: disabledInThisRun.map((d) => ({
               id: d.subscriptionId,
-              deliveryUrl: d.deliveryUrl,
+              deliveryUrl: redactDeliveryUrl(d.deliveryUrl),
               failed: d.failureCount,
               total: d.totalAttempts,
               failureRate: d.failureRatePercent,

--- a/api/src/webhook/webhook.service.ts
+++ b/api/src/webhook/webhook.service.ts
@@ -1004,6 +1004,8 @@ export class WebhookService {
           context: {
             name: user.name?.split(' ')?.[0] || 'there',
             title: 'Your webhook was paused',
+            subscriptionName: subscription.name ?? '',
+            deliveryUrl: subscription.deliveryUrl ?? '',
             failureCount,
             successCount,
             totalAttempts,
@@ -1011,7 +1013,6 @@ export class WebhookService {
             lookbackDays,
             ctaUrl: `${ctaUrlBase}/dashboard/account`,
             ctaLabel: 'Re-enable in dashboard',
-            brandName: 'textbee.dev',
           },
         })
       } catch (e) {
@@ -1034,8 +1035,13 @@ export class WebhookService {
             title: 'Webhook auto-disable summary',
             runAt,
             count: disabledInThisRun.length,
-            disabledList: disabledInThisRun,
-            brandName: 'textbee.dev',
+            rows: disabledInThisRun.map((d) => ({
+              id: d.subscriptionId,
+              deliveryUrl: d.deliveryUrl,
+              failed: d.failureCount,
+              total: d.totalAttempts,
+              failureRate: d.failureRatePercent,
+            })),
           },
         })
       } catch (e) {


### PR DESCRIPTION
## Summary

- MailService now merges the layout partial's context (brandName, year) into every templated email, so callers no longer repeat it.
- Webhook email callers pass the fields their templates use (subscription name and endpoint, and the summary table rows), and the admin summary template sets a preheader.
- Mail send failures are logged through the Nest logger with the template name.

## Test plan

- [x] Rendered every template under strict handlebars with each caller's context
- [x] api: jest for webhook, billing, auth, mail (128 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized branding and year information across email templates.
  - Added clearer preheader text for webhook auto-disable notifications.
  - Included subscription names and delivery URLs in user notifications.
  - Enhanced admin summaries with subscription IDs, failure counts, total attempts, and failure rates.
  - Improved email delivery error handling by redacting sensitive recipient and URL details from logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->