### PR TITLE
Tighten the recipient and endpoint redaction helpers

### DIFF
--- a/api/src/mail/mail.service.spec.ts
+++ b/api/src/mail/mail.service.spec.ts
@@ -55,11 +55,7 @@ describe('MailService', () => {
     })
   })
 
-  it.each([
-    ['Ada Lovelace <someone@example.com>'],
-    [['a@example.com', 'b@example.com']],
-    [{ name: 'Ada', address: 'someone@example.com' }],
-  ])('never leaks a recipient fragment for %p', async (to) => {
+  const logRecipientFor = async (to: unknown) => {
     const { service, mailerService } = build()
     const logger = jest
       .spyOn((service as any).logger, 'error')
@@ -72,10 +68,32 @@ describe('MailService', () => {
       template: 'password-reset-request',
     })
 
-    const message = logger.mock.calls[0][0] as string
-    expect(message).not.toContain('someone@example.com')
+    return logger.mock.calls[0][0] as string
+  }
+
+  it.each([
+    ['Ada Lovelace <someone@example.com>'],
+    [['a@example.com', 'b@example.com']],
+    [{ name: 'Ada' }],
+    [''],
+  ])('redacts a recipient it cannot mask safely: %p', async (to) => {
+    const message = await logRecipientFor(to)
+    expect(message).toContain('password-reset-request')
+    expect(message).toMatch(/to (redacted|unknown recipient): smtp down$/)
+  })
+
+  it('masks a structured recipient by its address alone', async () => {
+    const message = await logRecipientFor({
+      name: 'Ada Lovelace',
+      address: 'someone@example.com',
+    })
+    expect(message).toMatch(/to so\*\*\*@example\.com: smtp down$/)
     expect(message).not.toContain('Ada Lovelace')
-    expect(message).not.toContain('b@example.com')
+  })
+
+  it('masks a single-entry recipient list', async () => {
+    const message = await logRecipientFor(['someone@example.com'])
+    expect(message).toMatch(/to so\*\*\*@example\.com: smtp down$/)
   })
 
   it('swallows a send failure and logs a redacted recipient', async () => {
@@ -95,8 +113,8 @@ describe('MailService', () => {
     ).resolves.toBeUndefined()
 
     const message = logger.mock.calls[0][0] as string
-    expect(message).toContain('password-reset-request')
-    expect(message).toContain('so***@example.com')
-    expect(message).not.toContain('someone@example.com')
+    expect(message).toBe(
+      'Failed to send "password-reset-request" email to so***@example.com: smtp down',
+    )
   })
 })

--- a/api/src/mail/mail.service.spec.ts
+++ b/api/src/mail/mail.service.spec.ts
@@ -55,6 +55,29 @@ describe('MailService', () => {
     })
   })
 
+  it.each([
+    ['Ada Lovelace <someone@example.com>'],
+    [['a@example.com', 'b@example.com']],
+    [{ name: 'Ada', address: 'someone@example.com' }],
+  ])('never leaks a recipient fragment for %p', async (to) => {
+    const { service, mailerService } = build()
+    const logger = jest
+      .spyOn((service as any).logger, 'error')
+      .mockImplementation(() => undefined)
+    mailerService.sendMail.mockRejectedValue(new Error('smtp down'))
+
+    await service.sendEmailFromTemplate({
+      to: to as any,
+      subject: 'Password reset',
+      template: 'password-reset-request',
+    })
+
+    const message = logger.mock.calls[0][0] as string
+    expect(message).not.toContain('someone@example.com')
+    expect(message).not.toContain('Ada Lovelace')
+    expect(message).not.toContain('b@example.com')
+  })
+
   it('swallows a send failure and logs a redacted recipient', async () => {
     const { service, mailerService } = build()
     const logger = jest

--- a/api/src/mail/mail.service.ts
+++ b/api/src/mail/mail.service.ts
@@ -7,17 +7,23 @@ const layoutContext = () => ({
   year: new Date().getFullYear(),
 })
 
+/** One bare address, so a display name cannot leak through the mask. */
+const BARE_ADDRESS = /^[^\s<>@,"]+@[^\s<>@,"]+$/
+
 /** Keeps recipient addresses out of the logs while staying traceable. */
 const redactRecipient = (to: ISendMailOptions['to']): string => {
-  const first = Array.isArray(to) ? to[0] : to
-  const address = typeof first === 'string' ? first : first?.address
+  if (Array.isArray(to)) {
+    return to.length === 1 ? redactRecipient(to[0]) : 'redacted'
+  }
+  const address = typeof to === 'string' ? to : to?.address
   if (!address) {
     return 'unknown recipient'
   }
-  const [local, domain] = address.split('@')
-  if (!domain) {
+  const trimmed = address.trim()
+  if (!BARE_ADDRESS.test(trimmed)) {
     return 'redacted'
   }
+  const [local, domain] = trimmed.split('@')
   return `${local.slice(0, 2)}***@${domain}`
 }
 

--- a/api/src/webhook/webhook.service.spec.ts
+++ b/api/src/webhook/webhook.service.spec.ts
@@ -30,7 +30,7 @@ const build = () => {
 describe('redactDeliveryUrl', () => {
   it('drops userinfo and the query string', () => {
     expect(redactDeliveryUrl('https://user:pass@example.com/hook?token=secret')).toBe(
-      'https://example.com/hook?[redacted]',
+      'https://example.com/hook',
     )
   })
 

--- a/api/src/webhook/webhook.service.ts
+++ b/api/src/webhook/webhook.service.ts
@@ -30,8 +30,7 @@ export const redactDeliveryUrl = (deliveryUrl: string): string => {
   }
   try {
     const url = new URL(deliveryUrl)
-    const query = url.search ? '?[redacted]' : ''
-    return `${url.protocol}//${url.host}${url.pathname}${query}`
+    return `${url.protocol}//${url.host}${url.pathname}`
   } catch {
     return '[unparseable url]'
   }


### PR DESCRIPTION
## Summary

Follow-up to #323, covering the last two review points there.

- `redactRecipient` masks only a single bare address. A display name or a list of recipients now redacts whole rather than leaking a fragment.
- The admin summary endpoint shows origin and path only, without the query marker.

## Test plan

- [x] api: jest for mail and webhook (27 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Privacy**
  * Improved protection of recipient details in error logs across supported recipient formats.
  * Recipient addresses are validated and safely redacted, including multi-recipient and display-name formats.
  * Delivery URLs now omit query parameters entirely when displayed or logged, reducing exposure of sensitive information.

* **Tests**
  * Expanded coverage for recipient information redaction and updated URL-redaction expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->