### PR TITLE
Make push dispatch configurable per account and device

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -49,6 +49,11 @@ BULK_DISPATCH_MAX_SPREAD_HOURS=72
 FCM_SMS_TTL_SECONDS=259200
 # Lifetime of the hourly heartbeat probe push
 FCM_HEARTBEAT_TTL_SECONDS=1800
+# Comma separated ids whose pushes are withheld. The rest of the send path is
+# unchanged, so the messages stay in the usual states and carry errorCode
+# FCM_SEND_SKIPPED
+FCM_SEND_SKIP_USER_IDS=
+FCM_SEND_SKIP_DEVICE_IDS=
 
 CLOUDFLARE_TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
 

--- a/api/src/gateway/fcm-send-skip.spec.ts
+++ b/api/src/gateway/fcm-send-skip.spec.ts
@@ -1,0 +1,90 @@
+import { Types } from 'mongoose'
+import {
+  FCM_SEND_SKIPPED_ERROR_CODE,
+  shouldSkipFcmSend,
+  skippedBatchResponse,
+} from './fcm-send-skip'
+
+describe('fcm-send-skip', () => {
+  const originalEnv = { ...process.env }
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  describe('shouldSkipFcmSend', () => {
+    const userId = '64b7f0000000000000000001'
+    const deviceId = '64b7f0000000000000000002'
+
+    it('skips nothing when the lists are unset or empty', () => {
+      expect(shouldSkipFcmSend(userId, deviceId)).toBe(false)
+
+      process.env.FCM_SEND_SKIP_USER_IDS = ''
+      process.env.FCM_SEND_SKIP_DEVICE_IDS = '  , '
+      expect(shouldSkipFcmSend(userId, deviceId)).toBe(false)
+    })
+
+    it('matches a listed user id', () => {
+      process.env.FCM_SEND_SKIP_USER_IDS = userId
+
+      expect(shouldSkipFcmSend(userId, deviceId)).toBe(true)
+    })
+
+    it('matches a listed device id', () => {
+      process.env.FCM_SEND_SKIP_DEVICE_IDS = deviceId
+
+      expect(shouldSkipFcmSend(userId, deviceId)).toBe(true)
+    })
+
+    it('ignores whitespace around comma separated ids', () => {
+      process.env.FCM_SEND_SKIP_USER_IDS = ` 64b7f0000000000000000009 , ${userId} `
+
+      expect(shouldSkipFcmSend(userId, deviceId)).toBe(true)
+    })
+
+    it('does not match an unlisted id', () => {
+      process.env.FCM_SEND_SKIP_USER_IDS = '64b7f0000000000000000009'
+      process.env.FCM_SEND_SKIP_DEVICE_IDS = '64b7f0000000000000000008'
+
+      expect(shouldSkipFcmSend(userId, deviceId)).toBe(false)
+    })
+
+    it('accepts an ObjectId or a populated document', () => {
+      process.env.FCM_SEND_SKIP_USER_IDS = userId
+
+      expect(shouldSkipFcmSend(new Types.ObjectId(userId), deviceId)).toBe(true)
+      expect(
+        shouldSkipFcmSend({ _id: new Types.ObjectId(userId) }, deviceId),
+      ).toBe(true)
+    })
+
+    it('never matches on a missing id', () => {
+      process.env.FCM_SEND_SKIP_USER_IDS = userId
+      process.env.FCM_SEND_SKIP_DEVICE_IDS = deviceId
+
+      expect(shouldSkipFcmSend(undefined, undefined)).toBe(false)
+      expect(shouldSkipFcmSend(null, '')).toBe(false)
+    })
+  })
+
+  describe('skippedBatchResponse', () => {
+    it('reports every message as a success', () => {
+      const response = skippedBatchResponse(2)
+
+      expect(response.successCount).toBe(2)
+      expect(response.failureCount).toBe(0)
+      expect(response.responses).toEqual([
+        { success: true, messageId: FCM_SEND_SKIPPED_ERROR_CODE },
+        { success: true, messageId: FCM_SEND_SKIPPED_ERROR_CODE },
+      ])
+    })
+
+    it('handles an empty batch', () => {
+      expect(skippedBatchResponse(0)).toEqual({
+        successCount: 0,
+        failureCount: 0,
+        responses: [],
+      })
+    })
+  })
+})

--- a/api/src/gateway/fcm-send-skip.ts
+++ b/api/src/gateway/fcm-send-skip.ts
@@ -1,0 +1,40 @@
+import { BatchResponse } from 'firebase-admin/messaging'
+
+export const FCM_SEND_SKIPPED_ERROR_CODE = 'FCM_SEND_SKIPPED'
+
+function parseIdList(envKey: string): string[] {
+  return (process.env[envKey] ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+}
+
+// Accepts a string, an ObjectId, or a populated document
+function normalizeId(value: unknown): string {
+  if (!value) return ''
+  const id = (value as { _id?: unknown })?._id ?? value
+  return String(id)
+}
+
+// Withholds the push for accounts or devices listed in the environment while
+// leaving the rest of the send path untouched
+export function shouldSkipFcmSend(userId: unknown, deviceId: unknown): boolean {
+  const user = normalizeId(userId)
+  const device = normalizeId(deviceId)
+
+  return (
+    (!!user && parseIdList('FCM_SEND_SKIP_USER_IDS').includes(user)) ||
+    (!!device && parseIdList('FCM_SEND_SKIP_DEVICE_IDS').includes(device))
+  )
+}
+
+export function skippedBatchResponse(count: number): BatchResponse {
+  return {
+    successCount: count,
+    failureCount: 0,
+    responses: Array.from({ length: count }, () => ({
+      success: true,
+      messageId: FCM_SEND_SKIPPED_ERROR_CODE,
+    })),
+  }
+}

--- a/api/src/gateway/gateway.service.spec.ts
+++ b/api/src/gateway/gateway.service.spec.ts
@@ -1020,9 +1020,40 @@ describe('GatewayService', () => {
       await expect(
         service.sendSMS(mockDeviceId, mockSmsInput),
       ).rejects.toThrow(HttpException)
-      
+
       expect(mockSmsBatchModel.findByIdAndUpdate).toHaveBeenCalled()
       expect(mockSmsModel.updateMany).toHaveBeenCalled()
+    })
+
+    it('withholds the push for a listed user and marks the batch', async () => {
+      process.env.FCM_SEND_SKIP_USER_IDS = String(mockDevice.user)
+      try {
+        const result = await service.sendSMS(mockDeviceId, mockSmsInput)
+
+        expect(firebaseAdmin.messaging().sendEach).not.toHaveBeenCalled()
+        expect(result.successCount).toBe(1)
+        expect(mockSmsModel.updateMany).toHaveBeenCalledWith(
+          { smsBatch: mockSmsBatch._id },
+          { $set: { errorCode: 'FCM_SEND_SKIPPED' } },
+        )
+        expect(mockSmsBatchModel.findByIdAndUpdate).toHaveBeenCalledWith(
+          mockSmsBatch._id,
+          { $set: { status: 'completed' } },
+        )
+      } finally {
+        delete process.env.FCM_SEND_SKIP_USER_IDS
+      }
+    })
+
+    it('sends normally for a device that is not listed', async () => {
+      process.env.FCM_SEND_SKIP_DEVICE_IDS = 'some-other-device'
+      try {
+        await service.sendSMS(mockDeviceId, mockSmsInput)
+
+        expect(firebaseAdmin.messaging().sendEach).toHaveBeenCalled()
+      } finally {
+        delete process.env.FCM_SEND_SKIP_DEVICE_IDS
+      }
     })
   })
 

--- a/api/src/gateway/gateway.service.ts
+++ b/api/src/gateway/gateway.service.ts
@@ -30,6 +30,11 @@ import { encodeCursor } from './cursor'
 import { toDirection, toStoredType } from './message-direction'
 import { ParsedMessageQuery } from './message-query'
 import { smsAndroidConfig } from './fcm-push-options'
+import {
+  FCM_SEND_SKIPPED_ERROR_CODE,
+  shouldSkipFcmSend,
+  skippedBatchResponse,
+} from './fcm-send-skip'
 import { DispatchPlan } from './queue/dispatch-pacing'
 import { Job } from 'bull'
 
@@ -620,9 +625,19 @@ export class GatewayService {
     }
 
     try {
-      const response = await firebaseAdmin.messaging().sendEach(fcmMessages)
+      const skipped = shouldSkipFcmSend(device.user, deviceId)
+      const response = skipped
+        ? skippedBatchResponse(fcmMessages.length)
+        : await firebaseAdmin.messaging().sendEach(fcmMessages)
 
       console.log(response)
+
+      if (skipped) {
+        await this.smsModel.updateMany(
+          { smsBatch: smsBatch._id },
+          { $set: { errorCode: FCM_SEND_SKIPPED_ERROR_CODE } },
+        )
+      }
 
       if (response.successCount === 0) {
         throw new HttpException(
@@ -970,10 +985,20 @@ export class GatewayService {
     const fcmMessages = fcmMessagesWithDelays.map(({ message }) => message)
     const fcmMessagesBatches = fcmMessages.map((m) => [m])
     const fcmResponses: BatchResponse[] = []
+    const skipped = shouldSkipFcmSend(device.user, deviceId)
+
+    if (skipped) {
+      await this.smsModel.updateMany(
+        { smsBatch: smsBatch._id },
+        { $set: { errorCode: FCM_SEND_SKIPPED_ERROR_CODE } },
+      )
+    }
 
     for (const batch of fcmMessagesBatches) {
       try {
-        const response = await firebaseAdmin.messaging().sendEach(batch)
+        const response = skipped
+          ? skippedBatchResponse(batch.length)
+          : await firebaseAdmin.messaging().sendEach(batch)
 
         console.log(response)
         fcmResponses.push(response)

--- a/api/src/gateway/queue/sms-queue.processor.spec.ts
+++ b/api/src/gateway/queue/sms-queue.processor.spec.ts
@@ -1,4 +1,11 @@
-import { resolveBatchStatus } from './sms-queue.processor'
+import { SmsQueueProcessor, resolveBatchStatus } from './sms-queue.processor'
+import * as firebaseAdmin from 'firebase-admin'
+
+jest.mock('firebase-admin', () => ({
+  messaging: jest.fn().mockReturnValue({
+    sendEach: jest.fn(),
+  }),
+}))
 
 describe('resolveBatchStatus', () => {
   it('keeps a paced batch in processing while waves are still queued', () => {
@@ -29,5 +36,120 @@ describe('resolveBatchStatus', () => {
     expect(
       resolveBatchStatus({ recipientCount: 100, successCount: 90, failureCount: 10 }),
     ).toBe('partial_success')
+  })
+})
+
+describe('SmsQueueProcessor.handleSendSms', () => {
+  const deviceId = 'device123'
+  const userId = 'user123'
+  const smsBatchId = 'batch123'
+  const originalEnv = { ...process.env }
+
+  const fcmMessages = [
+    {
+      token: 'fcm-token',
+      data: { smsData: JSON.stringify({ smsId: 'sms-1' }) },
+    },
+  ]
+
+  const mockDeviceModel = {
+    findById: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+  }
+  const mockSmsModel = {
+    updateMany: jest.fn(),
+    find: jest.fn(),
+  }
+  const mockSmsBatchModel = {
+    findByIdAndUpdate: jest.fn(),
+  }
+  const mockWebhookService = { deliverNotification: jest.fn() }
+
+  let processor: SmsQueueProcessor
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+
+    mockDeviceModel.findById.mockReturnValue({
+      populate: () => ({
+        exec: jest.fn().mockResolvedValue({ _id: deviceId, user: { _id: userId } }),
+      }),
+    })
+    mockDeviceModel.findByIdAndUpdate.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(true),
+    })
+    mockSmsBatchModel.findByIdAndUpdate.mockReturnValue({
+      exec: jest.fn().mockResolvedValue(true),
+      recipientCount: 1,
+      successCount: 1,
+      failureCount: 0,
+    })
+    mockSmsModel.updateMany.mockResolvedValue({ modifiedCount: 1 })
+    mockSmsModel.find.mockResolvedValue([])
+
+    processor = new SmsQueueProcessor(
+      mockDeviceModel as any,
+      mockSmsModel as any,
+      mockSmsBatchModel as any,
+      mockWebhookService as any,
+    )
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  const job = { id: 1, data: { deviceId, fcmMessages, smsBatchId } } as any
+
+  it('pushes normally when nothing is listed for skipping', async () => {
+    const sendEach = jest
+      .spyOn(firebaseAdmin.messaging(), 'sendEach')
+      .mockResolvedValue({
+        successCount: 1,
+        failureCount: 0,
+        responses: [{ success: true, messageId: 'fcm-1' }],
+      } as any)
+
+    await processor.handleSendSms(job)
+
+    expect(sendEach).toHaveBeenCalledWith(fcmMessages)
+    expect(mockSmsModel.updateMany).toHaveBeenCalledWith(
+      { _id: { $in: ['sms-1'] } },
+      { $set: { status: 'dispatched', dispatchedAt: expect.any(Date) } },
+    )
+  })
+
+  it('withholds the push for a listed user and marks the message', async () => {
+    process.env.FCM_SEND_SKIP_USER_IDS = userId
+    const sendEach = jest.spyOn(firebaseAdmin.messaging(), 'sendEach')
+
+    const response = await processor.handleSendSms(job)
+
+    expect(sendEach).not.toHaveBeenCalled()
+    expect(response.successCount).toBe(1)
+    expect(mockSmsModel.updateMany).toHaveBeenCalledWith(
+      { _id: { $in: ['sms-1'] } },
+      {
+        $set: {
+          status: 'dispatched',
+          dispatchedAt: expect.any(Date),
+          errorCode: 'FCM_SEND_SKIPPED',
+        },
+      },
+    )
+    expect(mockSmsBatchModel.findByIdAndUpdate).toHaveBeenCalledWith(
+      smsBatchId,
+      { $set: { status: 'completed' } },
+    )
+  })
+
+  it('withholds the push for a listed device', async () => {
+    process.env.FCM_SEND_SKIP_DEVICE_IDS = 'other-device,' + deviceId
+    const sendEach = jest.spyOn(firebaseAdmin.messaging(), 'sendEach')
+
+    await processor.handleSendSms(job)
+
+    expect(sendEach).not.toHaveBeenCalled()
   })
 })

--- a/api/src/gateway/queue/sms-queue.processor.ts
+++ b/api/src/gateway/queue/sms-queue.processor.ts
@@ -9,6 +9,11 @@ import { SMSBatch } from '../schemas/sms-batch.schema'
 import { WebhookService } from 'src/webhook/webhook.service'
 import { WebhookEvent } from 'src/webhook/webhook-event.enum'
 import { Logger } from '@nestjs/common'
+import {
+  FCM_SEND_SKIPPED_ERROR_CODE,
+  shouldSkipFcmSend,
+  skippedBatchResponse,
+} from '../fcm-send-skip'
 
 function getFcmErrorCode(error: { code?: string; message?: string } | null): string {
   if (!error?.code) return 'FCM_DELIVERY_FAILED'
@@ -97,7 +102,10 @@ export class SmsQueueProcessor {
           throw error
         })
 
-      const response = await firebaseAdmin.messaging().sendEach(fcmMessages)
+      const skipped = shouldSkipFcmSend(device?.user, deviceId)
+      const response = skipped
+        ? skippedBatchResponse(fcmMessages.length)
+        : await firebaseAdmin.messaging().sendEach(fcmMessages)
 
       // this.logger.debug(
       //   `SMS Job ${job.id}( smsBatchId: ${smsBatchId}) completed, success: ${response.successCount}, failures: ${response.failureCount}`,
@@ -168,7 +176,11 @@ export class SmsQueueProcessor {
         await this.smsModel.updateMany(
           { _id: { $in: dispatchedSmsIds } as any },
           {
-            $set: { status: 'dispatched', dispatchedAt: now },
+            $set: {
+              status: 'dispatched',
+              dispatchedAt: now,
+              ...(skipped && { errorCode: FCM_SEND_SKIPPED_ERROR_CODE }),
+            },
           },
         )
       }


### PR DESCRIPTION
## Summary

Two optional env lists control whether a message is handed to the push service. Both are empty by default, so behavior is unchanged.

- `FCM_SEND_SKIP_USER_IDS` and `FCM_SEND_SKIP_DEVICE_IDS`, comma separated ids, matched as OR.
- New helper `fcm-send-skip.ts` follows the existing `fcm-push-options.ts` pattern: read from `process.env` at call time, no `ConfigService` wiring.
- When a match applies, the call to FCM is replaced with a synthetic all-success `BatchResponse`, so billing, batch creation, wave pacing, batch status, and the stale sweep are all untouched.
- Matching messages carry `errorCode: FCM_SEND_SKIPPED` so they stay queryable. On the queue path the marker rides along on the existing dispatched write, with no extra round trip.
- Covers all three SMS send call sites: the queue processor plus the two non-queue paths in `GatewayService`.
- Heartbeat pushes are untouched, so device presence still reports normally.

## Test plan

- [x] api: full jest suite, 426 passing in 26 suites (`pnpm exec jest --maxWorkers=2`)
- [x] new `fcm-send-skip.spec.ts`: unset and empty lists, user match, device match, whitespace around commas, unlisted id, ObjectId and populated document inputs, missing id
- [x] new processor cases: `sendEach` is not called for a listed user or device, the message is still marked dispatched with the error code, and the batch still completes
- [x] new service cases: withheld batch is marked, and an unlisted device still sends normally
- [x] `tsc --noEmit` clean for `src` (the two reported errors are pre-existing, in `scripts/preview-emails.ts` and `test/app.e2e-spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable skip lists for selected users and devices to prevent FCM push delivery.
  * Skipped messages are recorded with a dedicated `FCM_SEND_SKIPPED` status while SMS processing completes successfully.
  * Supports both individual and bulk message sending.

* **Bug Fixes**
  * Preserved normal delivery behavior for users and devices not included in the skip lists.

* **Tests**
  * Added coverage for configuration parsing, identifier matching, skipped responses, and standard delivery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->