### PR TITLE
fix: null-safe getAvailableSimSlots when no active SIM

### DIFF
--- a/android/app/src/main/java/com/vernu/sms/TextbeeUtils.java
+++ b/android/app/src/main/java/com/vernu/sms/TextbeeUtils.java
@@ -35,7 +35,9 @@ public class TextbeeUtils {
         }
 
         SubscriptionManager subscriptionManager = SubscriptionManager.from(context);
-        return subscriptionManager.getActiveSubscriptionInfoList();
+        List<SubscriptionInfo> sims = subscriptionManager.getActiveSubscriptionInfoList();
+        // getActiveSubscriptionInfoList() returns null when there is no active SIM.
+        return sims != null ? sims : new ArrayList<>();
 
     }
 


### PR DESCRIPTION
## Summary

fix: null-safe getAvailableSimSlots when no active SIM

## Changes

- SubscriptionManager.getActiveSubscriptionInfoList() can return null.
- Return an empty list instead so callers do not NPE and show Error: null.

Fixes #257


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling on Android devices without an active SIM by returning an empty SIM slot list instead of an unavailable value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->